### PR TITLE
fix: Provide front matter for checkout docs

### DIFF
--- a/pages/dev/Checkout-Extensibility.md
+++ b/pages/dev/Checkout-Extensibility.md
@@ -1,4 +1,7 @@
-# Checkout extensibility
+---
+title: Checkout Extensibility
+permalink: /Checkout-Extensibility/
+---
 
 ## Idea
 


### PR DESCRIPTION
Fix issue with checkout extensibility page not builded.

Provided frontmatter according to other pages.