### PR TITLE
Fix 1-oh dependencies for release

### DIFF
--- a/_pages/install/building-the-spartacus-storefront-from-libraries.md
+++ b/_pages/install/building-the-spartacus-storefront-from-libraries.md
@@ -84,10 +84,10 @@ The dependencies in this procedure are required by the Spartacus storefront.
    "i18next": "^15.0.6",
    "i18next-xhr-backend": "^2.0.1",
    
-   "@spartacus/core": "^1.0.0-RC.0",
-   "@spartacus/styles": "^1.0.0-RC.0",
-   "@spartacus/storefront": "^1.0.0-RC.0",
-   "@spartacus/assets": "^1.0.0-RC.0"
+   "@spartacus/core": "~1.0.0",
+   "@spartacus/styles": "~1.0.0",
+   "@spartacus/storefront": "~1.0.0",
+   "@spartacus/assets": "~1.0.0"
    ```
    
    Note: Make sure to add a comma to the end of the last dependency statement listed in this section. For example, the last statement in your new app might be `"zone.js": "~0.9.1"` so you would need to add a comma after `0.9.1"`.
@@ -101,7 +101,7 @@ The dependencies in this procedure are required by the Spartacus storefront.
 
 **Note:** 
 
-(1) Using `~` instructs yarn to use the latest minor version (x.y), whereas using `^` instructs yarn to use the latest patch version (x.y.z).
+(1) Using `~` instructs yarn to use the latest patch version (x.y.**z**), whereas using `^` instructs yarn to use the latest minor version (x.**y**.0).
 
 (2) If you are updating an existing app, and changing dependencies, it's recommended that you delete the `node_modules` folder before running the install command.
 


### PR DESCRIPTION
We released 1.0 July 4 but the installation doc still says RC.
Also the description of ~ vs ^ was inverted.