### PR TITLE
Remove old note about child routes in routing docs

### DIFF
--- a/_pages/dev/routes/adding-and-customizing-routes.md
+++ b/_pages/dev/routes/adding-and-customizing-routes.md
@@ -79,10 +79,7 @@ cmsComponents: {
     }
 }
 ```
-
-*Note: accessing children routes via a deep links to nested routes is not yet supported. You have to open firstly the parent route and then navigate to the child route via router link.*
-
-*Note 2: children routes of Product and Category Pages are not supported.*
+*Note: children routes of Product and Category Pages are not supported.*
 
 ## Advanced: How to configure category name in the Product Page route
 


### PR DESCRIPTION
It's working, so we don't need a note anymore.
See this cms-driven child route is working OK https://spartacus.c39j2-walkersde1-d4-public.model-t.cc.commerce.ondemand.com/electronics-spa/en/USD/store-finder/country/BE/sap-brussels-education-center-office