### PR TITLE
TUA - For replacing the release date in the current topics with September 8, 2020 (Doc/gh 749)

### DIFF
--- a/_pages/telco/telco-release-information.md
+++ b/_pages/telco/telco-release-information.md
@@ -2,7 +2,7 @@
 title: Release Information for Version 1.0.0 of TUA Spartacus Libraries
 ---
 
-*Last updated July 24, 2020 by Deborah Cholmeley-Jones, Solution Owner, TUA Spartacus*
+*Last updated September 8, 2020 by Deborah Cholmeley-Jones, Solution Owner, TUA Spartacus*
 
 
 Release 1.0 is the very first release of the TUA Spartacus libraries, and at this time, we have only pre-releases available for 1.0. To learn more about what our pre-releases have to offer, see [Pre-Release Information]({{ site.baseurl }}{% link _pages/telco/tua-pre-release-information.md %}).

--- a/_pages/telco/tua-spartacus-roadmap.md
+++ b/_pages/telco/tua-spartacus-roadmap.md
@@ -2,7 +2,7 @@
 title: Roadmap for TUA Spartacus
 ---
 
-*Last updated July 24, 2020 by Deborah Cholmeley-Jones, Solution Owner, TUA Spartacus*
+*Last updated September 8, 2020 by Deborah Cholmeley-Jones, Solution Owner, TUA Spartacus*
 
 This document describes what is planned for TUA Spartacus for Q2 2020 and later.
 


### PR DESCRIPTION
Replaced the release date in the two topics with September 8, 2020 as per the discussion in the SPA meeting. Did not update the date in the pre-release topic. 
For peer review, open **Spartacus Documentation.html** in the browser navigate to TUA Spartacus documentation at the bottom of the page and then confirm the updated release date in: 

1. Release Information for Version 1.0.0 of TUA Spartacus Libraries topic, and
2. Roadmap for TUA Spartacus.

[Spartacus Documentation_files.zip](https://github.com/SAP/spartacus-docs/files/5188657/Spartacus.Documentation_files.zip)

