### PR TITLE
Document code splitting of components and modules

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -159,7 +159,7 @@ docs:
                   url: /pagination/  
                 - title: 'Searchbox Component'
                   url: /searchbox-component/
-          - title: "Lazy-loading Guide"
+          - title: "Lazy Loading Guide"
             url: /lazy-loading-guide/
           - title: "Extending Checkout"
             url: /extending-checkout/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -128,7 +128,7 @@ docs:
                 - title: "Deferred Loading"
                   url: /deferred-loading/
                 - title: "Above-the-Fold Loading"
-                  url: /above-the-fold/  
+                  url: /above-the-fold/
           - title: "Outlets"
             url: /outlets/        
           - title: "Styling and Page Layout ➢"
@@ -159,6 +159,8 @@ docs:
                   url: /pagination/  
                 - title: 'Searchbox Component'
                   url: /searchbox-component/
+          - title: "Lazy-loading Guide"
+            url: /lazy-loading-guide/
           - title: "Extending Checkout"
             url: /extending-checkout/
           - title: "Express Checkout"

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -1,0 +1,201 @@
+---
+title: Lazy Loading Guide
+---
+
+**Lazy loading or code splitting** lets you divide the JavaScript code into multiple chunks, so they don't have to be loaded upfront, but only when actually needed, greatly improving Time To Interactive, especially in case of complex web applications and on lower-end mobile devices. 
+
+## Spartacus Approach to Lazy Loading
+   
+As Spartacus is mostly CMS driven, there is not much of the usage of the built-in route based lazy loading offered by Angular out of the box. Code splitting has to be done at app build time, while Spartacus never knows upfront what components or features a specific route can contain, before actually loading them. 
+There is always a room for manual tweaking it based on app knowledge, but such a solution breaks the flexibility that Spartacus offers and requires additional prerequisites.
+   
+To meet those requirements, Spartacus provides CMS driven lazy loading on two different layers:
+ 
+   	1. Lazy loading of CMS components (simplest)
+   	
+    2. CMS driven lazy loading of feature modules
+    
+    
+## Important information
+
+### Dynamic imports can only be defined in the main application
+
+**Dynamic imports**, a technique used to facilitate lazy loading and allow for code splitting, can be only used in the main application, it's not possible to define them in prebuild libraries.
+
+### Avoid static imports for lazy loaded code
+
+To make code spitting possible, your static javascript code (main app bundle) shouldn't have any static imports to code that you want to lazy load. The builder will notice, that the code is already included and won't generate a separate chunk for it.
+
+It's especially important in the case of importing symbols from libraries. 
+At the time of writing (Angular 9 and Angular 10), mixing static imports with dynamic imports for the same library entry point, even for distinct symbols, will break lazy loading and tree shaking for this library entry point, including the whole entry point statically. 
+That's why **it's recommended to create separate entry points** for the code, that has to be loaded statically and the code that can be loaded lazily. 
+
+### Configuration in lazy loaded modules
+
+Lazy loaded configuration won't be visible for other modules and won't contribute to the global configuration of the running app. 
+
+This will be addressed in Spartacus 3.x with the concept of unified configuration, for Spartacus 2.1 you should import modules with configuration statically.
+
+### Providers in lazy loaded modules
+
+Injection tokens provided in lazy loaded modules won't be visible to services provided in the app root, it especially applies to multi provided tokens, like PageMetaResolvers, various Handlers, etc. 
+
+This problem will be partially addressed in Spartacus 3.0 with the Unified Injector mechanism, for Spartacus 2.1 you should always provide those tokens in modules statically imported to your app root module. 
+
+### Avoid importing **HttpClientModule** in your lazy loaded modules
+
+Generally **HttpClientModule** should be imported in the root application, not in the library.
+For example: importing it inside a lazy loaded library will make all injectors from the root library invisible to http calls originating from lazy loaded module.
+
+Technically it's possible, but in most cases, it's not something that is expected and might cause some hard to explain errors, so please take it into consideration. 
+
+
+## Lazy loading of CMS components
+_(available in Spartacus 2.0 and above)_
+
+
+### The Configuration
+
+Lazy loading of CMS code is achieved by specifying dynamic import in place of statically referenced components class in CMS Mapping configuration:
+
+```typescript
+{
+  cmsComponents: {
+    SimpleResponsiveBannerComponent: {
+      component: () => import('./lazy/lazy.component').then(m => m.LazyComponent)
+    }
+  }
+}
+```
+
+You can find more information about CMS Mapping here: [Customizing CMS Components]({{ site.baseurl }}{% link _pages/dev/customizing-cms-components.md %}) 
+
+
+### Technical details
+
+Support for dynamic imports in Cms Component Mapping is implemented using customizable Component Handlers, specificially the **LazyComponentHandler**. 
+
+It's possible to extend this handled to customize its behavior, add special hooks, different triggers, or implement a completely new handler that can optionally reuse existing ones.    
+
+
+## Lazy loading of modules
+_(available in Spartacus 2.1 and above)_
+
+CMS driven lazy loading of feature modules allows to:
+
+  - Lazy load not only component code, but also core part (including NgRx state)
+  - Feature is loaded only once, when first needed
+  - Provide shared, lazy loaded dependency modules
+
+Lazy loading of the feature module is triggered by CMS requesting a component, which implementation is provided specific feature. 
+
+### The Configuration
+
+Configuration for the feature contains two parts: 
+
+  1. The dynamic import of the feature module (has to be defined in main application)
+  2. The information about what CMS components are covered by this feature (can become part of the library and imported statically). The information is provided as an array of strings under __cmsComponents__ key. 
+
+```typescript
+{
+  featureModules: {
+    organization: {
+      module: () =>
+        import('@spartacus/my-account/organization').then(
+          (m) => m.OrganizationModule
+        ),
+      cmsComponents: [
+        'OrderApprovalListComponent',
+        'ManageBudgetsListComponent',
+        'ManageCostCentersListComponent',
+        'ManagePermissionsListComponent',
+        'ManageUnitsListComponent',
+        'ManageUserGroupsListComponent',
+        'ManageUsersListComponent',
+      ],
+    },
+  },
+}
+```
+
+### Defining shared dependency modules 
+
+It's possible to extract some logic to shared lazy loaded module that can be defined as lazy loaded dependency for feature module by providing array of dynamic imports in __dependencies__ property in feature configuration.  
+
+```typescript
+{
+  featureModules: {
+    organization: {
+      module: () =>
+        import('@spartacus/my-account/organization').then(
+          (m) => m.OrganizationModule
+        ),
+      dependencies: [
+        () =>
+          import('@spartacus/storefinder/core').then(
+            (m) => m.OrganizationModule
+          ),
+        // ,,
+      ],
+    },
+  },
+}
+```
+
+Such a unnamed dependency modules are instantiated only once, when lazy loading the first feature that depends on it, and its providers are contributing to Combined Injector that is passed to CMS Component covered by the  feature.  
+
+
+### Combined Injector
+
+When CMS component covered by lazy-loaded module is instantiated, it can inject (have access to) services from:
+ 
+   - app root injector, taking into account hierarchical injector component tree (i.e. providers defined in parent components)
+   - feature module injector
+   - dependency modules injectors
+   
+It's achieved thanks to **CombinedInjector** that is created on the fly by CMS rendering logic. By the rule of thumb, local hierarchical providers take precedence before feature module providers, which in turn takes precedence before dependency module injectors, which take precedence before the root Application injector. 
+
+
+## Preparing libraries to work with lazy loading
+
+### Providing fine-grained entry points in your library
+
+Because mixing static and dynamic imports from the same entry points break lazy loading and affects tree shaking, any library that will be used directly in dynamic imports should expose fine-grained secondary entry points to optimize code splitting. 
+
+For more information, please read about 
+[Secondary Entry Points](https://github.com/ng-packagr/ng-packagr/blob/master/docs/secondary-entrypoints.md) in **ng-packagr**.
+
+
+### Separating static code from lazy loaded
+
+Because of how Angular Dependency Injection works, the list of providers in the Injector should not change after Injector was initialized. 
+This paradigm specifically affects:
+  
+  1. Spartacus configuration which is defined by providing configuration chunks that are merged in global Configuration Factory Provider.
+  
+  2. Any multi provided tokens, handlers like PageMetaResolver, ErrorHandler, etc.
+  
+  3. Any Angular native multi provided tokens, like HTTP_INTERCEPTOR, APP_INITIALIZER, etc.   
+  
+It means, that any configuration or multi provided token in lazy loaded module won't be visible to modules and services provided in root or in other lazy loaded chunks.
+ 
+The easiest way to fix it is to always include such a code in a statically linked module, available upfront. We recommend creating a separate entry point in your library, by convention named _root_ (i.e. 'my-library/root') that contains minimal code that will be included in the main bundle and will be available from the beginning.
+
+### Wrapping library code in lazy loaded module
+
+To address some specific customizations on top of a lazy loaded library, it's possible to wrap static imports from one or more libraries in one module that will be imported dynamically instead.
+This technique can be also an effective optimization strategy, as the builder will be able to use tree shaking for all the static imports inside the module.   
+
+
+## Additional mechanisms (planned for Spartacus 3.0)
+
+### Unified Configuration
+_(preview available in 3.0-next releases)_
+
+Provides a way to get a global configuration that will include both root configuration + configuration from already loaded lazy loaded modules.
+
+### Unified Injector
+_(preview available in 3.0-next releases)_
+
+Provides a way to inject a token or multi provided tokens taking into and account root injector and injectors from lazy loaded modules.
+Injector exposes an Observable, that will emit each time status of the Unified Injector for specified token will change.

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -9,11 +9,10 @@ title: Lazy Loading Guide
 ## Spartacus Approach to Lazy Loading
    
 As Spartacus is mostly CMS driven, there is not much of the usage of the built-in route based lazy loading offered by Angular out of the box. Code splitting has to be done at app build time, while Spartacus never knows upfront what components or features a specific route can contain, before actually loading them. 
-There is always a room for manual tweaking it based on app knowledge, but such a solution breaks the flexibility that Spartacus offers and requires additional prerequisites.
    
 To meet those requirements, Spartacus provides CMS driven lazy loading on two levels:
  
-  1. Lazy loading of CMS components (simplest)
+  1. Lazy loading of CMS components
    	
   2. CMS driven lazy loading of feature modules
     

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -2,7 +2,9 @@
 title: Lazy Loading Guide
 ---
 
-**Lazy loading or code splitting** lets you divide the JavaScript code into multiple chunks, so they don't have to be loaded upfront, but only when actually needed, greatly improving Time To Interactive, especially in case of complex web applications and on lower-end mobile devices. 
+**Lazy loading or code splitting** lets you divide the JavaScript code into multiple chunks, so they don't have to be loaded upfront, but only when actually needed.
+
+ Such an approach can substantially improve Time To Interactive, especially in case of complex web applications and  lower-end mobile devices. 
 
 ## Spartacus Approach to Lazy Loading
    

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -2,15 +2,13 @@
 title: Lazy Loading Guide
 ---
 
-Lazy loading, also known as code splitting, lets you divide your JavaScript code into multiple chunks. The result is that you do not have to load all of the chunks when a user first accesses your storefront. Instead, chunks are only loaded when they are needed.
+Lazy loading, also known as code splitting, lets you divide your JavaScript code into multiple chunks. The result is that you do not have to load all the JavaScript of the full application when a user accesses the first page. Instead, only the chunks that are required for the given page are loaded. While navigating the storefront, additional chunks might be loaded when needed.
 
 Such an approach can substantially improve "Time To Interactive", especially in the case of complex web applications being accessed by low-end mobile devices.
 
 ## Spartacus Approach to Lazy Loading
 
-Spartacus is mostly CMS driven, which means Spartacus does not use much of the built-in, route-based lazy loading that is offered out-of-the-box by Angular. Code splitting has to be done at app build time, although Spartacus cannot know what components or features a specific route can contain before actually loading them.
-
-As a result, Spartacus provides CMS-driven lazy loading in the following ways:
+Code splitting is a technique that has to be done at application build time. Code splitting provided by Angular is typically route-based, which means there is a chunk for the landing page, another chunk for the product page, and so on. Since Spartacus is mostly CMS driven, the actual application logic for each route cannot be decided at build time. Business users will eventually alter the page structure by introducing or removing components. This is why an alternative approach to lazy-loading is required, which Spartacus provides in the following ways:
 
 - Lazy loading of CMS components
 - CMS-driven lazy loading of feature modules

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -11,23 +11,23 @@ There is always a room for manual tweaking it based on app knowledge, but such a
    
 To meet those requirements, Spartacus provides CMS driven lazy loading on two levels:
  
-   	1. Lazy loading of CMS components (simplest)
+  1. Lazy loading of CMS components (simplest)
    	
-    2. CMS driven lazy loading of feature modules
+  2. CMS driven lazy loading of feature modules
     
     
 ## Important information
 
 ### Dynamic imports can only be defined in the main application
 
-**Dynamic imports**, a technique used to facilitate lazy loading and allow for code splitting, can be only used in the main application, it's not possible to define them in prebuild libraries.
+**Dynamic imports**, a technique used to facilitate lazy loading and allow for code splitting, can be only used in the main application. It's not possible to define them in prebuild libraries.
 
 ### Avoid static imports for lazy loaded code
 
 To make code spitting possible, your static javascript code (main app bundle) shouldn't have any static imports to code that you want to lazy load. The builder will notice, that the code is already included and won't generate a separate chunk for it.
 
 It's especially important in the case of importing symbols from libraries. 
-At the time of writing (Angular 9 and Angular 10), mixing static imports with dynamic imports for the same library entry point, even for distinct symbols, will break lazy loading and tree shaking for this library entry point, including the whole entry point statically. 
+At the time of writing (Angular 9 and Angular 10), mixing static imports with dynamic imports for the same library entry point, even for distinct symbols, will break lazy loading and tree shaking for this library entry point, including the whole entry point statically into the build. 
 That's why **it's recommended to create separate entry points** for the code, that has to be loaded statically and the code that can be loaded lazily. 
 
 ### Configuration in lazy loaded modules
@@ -117,6 +117,16 @@ Configuration for the feature contains two parts:
   },
 }
 ```
+
+### Component Mapping Configuration in Lazy Loaded Modules
+
+Default CMS Mapping Configuration in lazy loaded modules should be defined in exactly the same fashion as in statically imported ones.
+
+Spartacus is able to extract CMS component mapping configuration from a lazy-loaded feature and use it to resolve component classes and factories covered by the feature. That's why it's possible and advised to use the standard way of providing default CMS Mapping configuration inside a lazy loaded module. Thanks to it:
+
+ - The exact same module and library entry point can be imported dynamically or statically, depending on the needs
+ - It's still possible to overwrite lazy-loaded CMS configuration from the Application level, providing config overrides in the application.   
+
 
 ### Defining shared dependency modules 
 

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -2,64 +2,61 @@
 title: Lazy Loading Guide
 ---
 
-**Lazy loading or code splitting** lets you divide the JavaScript code into multiple chunks, so they don't have to be loaded upfront, but only when actually needed.
+Lazy loading, also known as code splitting, lets you divide your JavaScript code into multiple chunks. The result is that you do not have to load all of the chunks when a user first accesses your storefront. Instead, chunks are only loaded when they are needed.
 
- Such an approach can substantially improve Time To Interactive, especially in case of complex web applications and  lower-end mobile devices. 
+Such an approach can substantially improve "Time To Interactive", especially in the case of complex web applications being accessed by low-end mobile devices.
 
 ## Spartacus Approach to Lazy Loading
-   
-As Spartacus is mostly CMS driven, there is not much of the usage of the built-in route based lazy loading offered by Angular out of the box. Code splitting has to be done at app build time, while Spartacus never knows upfront what components or features a specific route can contain, before actually loading them. 
-   
-To meet those requirements, Spartacus provides CMS driven lazy loading on two levels:
- 
-  1. Lazy loading of CMS components
-   	
-  2. CMS driven lazy loading of feature modules
-    
-    
-## Important information
 
-### Dynamic imports can only be defined in the main application
+Spartacus is mostly CMS driven, which Spartacus does not use much of the built-in, route-based lazy loading that is offered out-of-the-box by Angular. Code splitting has to be done at app build time, although Spartacus cannot know what components or features a specific route can contain before actually loading them.
 
-**Dynamic imports**, a technique used to facilitate lazy loading and allow for code splitting, can be only used in the main application. It's not possible to define them in prebuild libraries.
+As a result, Spartacus provides CMS-driven lazy loading in the following ways:
 
-This is an unfortunate limitation, that results in some application code that must be added by customers. While the amount of custom code is limited to the bare minimum, we'll add a feature in a future version of the schematics library to automatically add lazy loaded modules.
+- Lazy loading of CMS components
+- CMS-driven lazy loading of feature modules
 
-### Avoid static imports for lazy loaded code
+## General Concepts
 
-To make code spitting possible, your static javascript code (main app bundle) shouldn't have any static imports to code that you want to lazy load. The builder will notice, that the code is already included and won't generate a separate chunk for it.
+The following sections offer some important information about how lazing loading works in Spartacus.
 
-It's especially important in the case of importing symbols from libraries. 
-At the time of writing (Angular 9 and Angular 10), mixing static imports with dynamic imports for the same library entry point, even for distinct symbols, will break lazy loading and tree shaking for this library entry point, including the whole entry point statically into the build. 
-That's why **it's recommended to create separate entry points** for the code, that has to be loaded statically and the code that can be loaded lazily. 
+### Define Dynamic Imports Only in the Main Application
 
-### Configuration in lazy loaded modules
+Dynamic imports, a technique that is used to facilitate lazy loading and that also allows code splitting, can only be used in the main application. It is not possible to define dynamic imports in the prebuilt libraries.
 
-Lazy loaded configuration won't be visible for other modules and won't contribute to the global configuration of the running app. 
+This is an unfortunate limitation, which results in some application code that must be added by customers. Although the amount of custom code is limited to the bare minimum, we'll add a feature in a future version of the schematics library to automatically add lazy loaded modules.
 
-This will be addressed in Spartacus 3.x with the concept of unified configuration, for Spartacus 2.1 you should import modules with configuration statically.
+### Avoiding Static Imports for Lazy Loaded Code
 
-### Providers in lazy loaded modules
+To make code spitting possible, your static JavaScript code (the main app bundle) should not have any static imports to code that you want to lazy load. The builder will notice that the code is already included, and as a result, will not generate a separate chunk for it. This is especially important in the case of importing symbols from libraries.
 
-Injection tokens provided in lazy loaded modules won't be visible to services provided in the app root, it especially applies to multi provided tokens, like PageMetaResolvers, various Handlers, etc. 
+At the time of writing (Angular 9 and Angular 10), mixing static imports with dynamic imports for the same library entry point, even for distinct symbols, will break lazy loading and tree shaking for this library entry point. This includes the whole entry point statically into the build. For this reason, it is highly recommended you create separate entry points for the code that has to be loaded statically, and for the code that can be loaded lazily.
 
-This problem will be partially addressed in Spartacus 3.0 with the Unified Injector mechanism, for Spartacus 2.1 you should always provide those tokens in modules statically imported to your app root module. 
+### Configuration in Lazy Loaded Modules
 
-### Avoid importing **HttpClientModule** in your lazy loaded modules
+The lazy loaded configuration is not be visible to other modules and does not contribute to the global configuration of the running application. This will be addressed in Spartacus 3.x with the concept of unified configuration. For Spartacus 2.1, you should import modules with configuration statically.
 
-Generally **HttpClientModule** should be imported in the root application, not in the library.
-For example: importing it inside a lazy loaded library will make all injectors from the root library invisible to http calls originating from lazy loaded module.
+### Providers in Lazy Loaded Modules
 
-Technically it's possible, but in most cases, it's not something that is expected and might cause some hard to explain errors, so please take it into consideration. 
+Injection tokens provided in lazy-loaded modules are not visible to services provided in the app root. This applies especially to multi-provided tokens, such as `PageMetaResolvers`, various Handlers, and so on. This problem will be partially addressed in Spartacus 3.0 with the Unified Injector mechanism. For Spartacus 2.1, you should always provide these tokens in modules statically imported to your app root module.
 
+### Avoiding Importing the HttpClientModule in Your Lazy Loaded Modules
 
-## Lazy loading of CMS components
-_(available in Spartacus 2.0 and above)_
+In general, the `HttpClientModule` should be imported in the root application, not in the library. For example, if you import it inside a lazy-loaded library, all injectors from the root library will be invisible to HTTP calls originating from the lazy-loaded module.
+
+Although technically it is possible to import the `HttpClientModule` in the library, in most cases it is not something that is expected, and it might cause errors that are difficult to explain, so please keep this in mind.
+
+## Lazy Loading of CMS components
+
+{% capture version_note %}
+{{ site.version_note_part1 }} 2.0 {{ site.version_note_part2 }}
+{% endcapture %}
+
+{% include docs/feature_version.html content=version_note %}
 
 
-### The Configuration
+### Configuration of Lazy Loading CMS Components
 
-Lazy loading of CMS code is achieved by specifying dynamic import in place of statically referenced components class in CMS Mapping configuration:
+Lazy loading of CMS code is achieved by specifying a dynamic import in place of a statically-referenced components class in the CMS Mapping configuration. The following is an example:
 
 ```typescript
 {
@@ -71,69 +68,68 @@ Lazy loading of CMS code is achieved by specifying dynamic import in place of st
 }
 ```
 
-You can find more information about CMS Mapping here: [Customizing CMS Components]({{ site.baseurl }}{% link _pages/dev/customizing-cms-components.md %}) 
+For more information on CMS mapping, see [Customizing CMS Components]({{ site.baseurl }}{% link _pages/dev/customizing-cms-components.md %}).
 
+### Technical Details
 
-### Technical details
+Support for dynamic imports in CMS component mapping is implemented using customizable component handlers (specifically, the `LazyComponentHandler`).
 
-Support for dynamic imports in Cms Component Mapping is implemented using customizable Component Handlers, specificially the **LazyComponentHandler**. 
+It is possible to extend this handler to customize its behavior, to add special hooks, or different triggers, or to implement a completely new handler that can optionally reuse existing ones.
 
-It's possible to extend this handled to customize its behavior, add special hooks, different triggers, or implement a completely new handler that can optionally reuse existing ones.    
+## Lazy Loading of Modules
 
+{% capture version_note %}
+{{ site.version_note_part1 }} 2.1 {{ site.version_note_part2 }}
+{% endcapture %}
 
-## Lazy loading of modules
-_(available in Spartacus 2.1 and above)_
+{% include docs/feature_version.html content=version_note %}
 
-CMS driven lazy loading of feature modules allows to:
+CMS-driven lazy loading of feature modules allows the following:
 
-  - Lazy load not only component code, but also core part (including NgRx state)
-  - Feature is loaded only once, when first needed
-  - Provide shared, lazy loaded dependency modules
+- Lazy loading not only component code, but also the core part (including NgRx state)
+- Loading a feature only once, when first needed
+- Providing shared, lazy-loaded dependency modules
 
-Lazy loading of the feature module is triggered by CMS requesting a component, which implementation is provided specific feature. 
+Lazy loading of the feature module is triggered by the CMS requesting a component when the implementation is covered by the relevant feature configuration.
 
-### The Configuration
+### Configuration of Lazy Loaded Modules
 
-Configuration for the feature contains two parts: 
+Configuration of the feature involves the following aspects:
 
-  1. The dynamic import of the feature module (has to be defined in main application)
-  2. The information about what CMS components are covered by this feature (can become part of the library and imported statically). The information is provided as an array of strings under __cmsComponents__ key. 
+- The dynamic import of the feature module (which has to be defined in main application)
+- The information about what CMS components are covered by a specific feature (which can become part of the library and imported statically). This information is provided as an array of strings under the `cmsComponents` key. The following is an example:
 
-```typescript
-{
-  featureModules: {
-    organization: {
-      module: () =>
-        import('@spartacus/my-account/organization').then(
-          (m) => m.OrganizationModule
-        ),
-      cmsComponents: [
-        'OrderApprovalListComponent',
-        'ManageBudgetsListComponent',
-        'ManageCostCentersListComponent',
-        'ManagePermissionsListComponent',
-        'ManageUnitsListComponent',
-        'ManageUserGroupsListComponent',
-        'ManageUsersListComponent',
-      ],
+  ```typescript
+  {
+    featureModules: {
+      organization: {
+        module: () =>
+          import('@spartacus/my-account/organization').then(
+            (m) => m.OrganizationModule
+          ),
+        cmsComponents: [
+          'OrderApprovalListComponent',
+          'ManageBudgetsListComponent',
+          'ManageCostCentersListComponent',
+          'ManagePermissionsListComponent',
+          'ManageUnitsListComponent',
+          'ManageUserGroupsListComponent',
+          'ManageUsersListComponent',
+        ],
+      },
     },
-  },
-}
-```
+  }
+  ```
 
-### Component Mapping Configuration in Lazy Loaded Modules
+### Component Mapping Configuration in Lazy-Loaded Modules
 
-Default CMS Mapping Configuration in lazy loaded modules should be defined in exactly the same fashion as in statically imported ones.
+Default CMS mapping configuration in lazy-loaded modules should be defined in exactly the same fashion as in statically-imported ones.
 
-Spartacus is able to extract CMS component mapping configuration from a lazy-loaded feature and use it to resolve component classes and factories covered by the feature. That's why it's possible and advised to use the standard way of providing default CMS Mapping configuration inside a lazy loaded module. Thanks to it:
+Spartacus is able to extract a CMS component mapping configuration from a lazy-loaded feature and use it to resolve component classes and factories covered by the feature. That is why it is possible and recommended to use the standard way of providing the default CMS mapping configuration inside a lazy loaded module. As a result, the exact same module and library entry point can be imported dynamically or statically, depending on the needs, and it is still possible to overwrite a lazy-loaded CMS configuration from the application level by providing configuration overrides in the application.
 
- - The exact same module and library entry point can be imported dynamically or statically, depending on the needs
- - It's still possible to overwrite lazy-loaded CMS configuration from the Application level, providing config overrides in the application.   
+### Defining Shared-Dependency Modules
 
-
-### Defining shared dependency modules 
-
-It's possible to extract some logic to shared lazy loaded module that can be defined as lazy loaded dependency for feature module by providing array of dynamic imports in __dependencies__ property in feature configuration.  
+It is possible to extract some logic to a shared, lazy-loaded module that can be defined as a lazy-loaded dependency for a feature module by providing an array of dynamic imports in the `dependencies` property of the feature configuration. The following is an example:  
 
 ```typescript
 {
@@ -155,60 +151,54 @@ It's possible to extract some logic to shared lazy loaded module that can be def
 }
 ```
 
-Such a unnamed dependency modules are instantiated only once, when lazy loading the first feature that depends on it, and its providers are contributing to Combined Injector that is passed to CMS Component covered by the  feature.  
-
+Such unnamed dependency modules are instantiated only once, when lazy loading the first feature that depends on it. Its providers contribute to the combined injector that is passed to the CMS component that is covered by the feature.  
 
 ### Combined Injector
 
-When CMS component covered by lazy-loaded module is instantiated, it can inject (have access to) services from:
- 
-   - app root injector, taking into account hierarchical injector component tree (i.e. providers defined in parent components)
-   - feature module injector
-   - dependency modules injectors
-   
-It's achieved thanks to **CombinedInjector** that is created on the fly by CMS rendering logic. By the rule of thumb, local hierarchical providers take precedence before feature module providers, which in turn takes precedence before dependency module injectors, which take precedence before the root Application injector. 
+When a CMS component that is covered by a lazy-loaded module is instantiated, it can inject (have access to) services from the following:
 
+- the app root injector, taking into account the hierarchical injector component tree (that is, providers defined in the parent components)
+- the feature module injector
+- the dependency modules injectors
 
-## Preparing libraries to work with lazy loading
+This is achieved thanks to the `CombinedInjector` that is created on the fly by the CMS rendering logic. As a rule of thumb, local hierarchical providers take precedence over feature module providers, which in turn takes precedence over dependency module injectors, which take precedence over the root application injector.
 
-### Providing fine-grained entry points in your library
+## Preparing Libraries to Work with Lazy Loading
 
-Because mixing static and dynamic imports from the same entry points break lazy loading and affects tree shaking, any library that will be used directly in dynamic imports should expose fine-grained secondary entry points to optimize code splitting. 
+### Providing Fine-Grained Entry Points in Your Library
 
-For more information, please read about 
-[Secondary Entry Points](https://github.com/ng-packagr/ng-packagr/blob/master/docs/secondary-entrypoints.md) in **ng-packagr**.
+Mixing static and dynamic imports from the same entry points breaks lazy loading and affects tree shaking, so any library that will be used directly in dynamic imports should expose fine-grained secondary entry points to optimize code splitting.
 
+For more information, see [Secondary Entry Points](https://github.com/ng-packagr/ng-packagr/blob/master/docs/secondary-entrypoints.md) in the ng-packagr documentation on GitHub.
 
-### Separating static code from lazy loaded
+### Separating Static Code from Lazy Loaded Code
 
-Because of how Angular Dependency Injection works, the list of providers in the Injector should not change after Injector was initialized. 
-This paradigm specifically affects:
+When you work with Angular Dependency Injection, the list of providers in the injector should not change after the injector is initialized. This paradigm specifically affects the following:
   
-  1. Spartacus configuration which is defined by providing configuration chunks that are merged in global Configuration Factory Provider.
+- The Spartacus configuration, which is defined by providing configuration chunks that are merged in the global Configuration Factory Provider.
+
+- Any multi-provided tokens, handlers such as `PageMetaResolver`, `ErrorHandler`, and so on.
   
-  2. Any multi provided tokens, handlers like PageMetaResolver, ErrorHandler, etc.
+- Any Angular native multi-provided tokens, such as `HTTP_INTERCEPTOR`, `APP_INITIALIZER`, and so on.
   
-  3. Any Angular native multi provided tokens, like HTTP_INTERCEPTOR, APP_INITIALIZER, etc.   
-  
-It means, that any configuration or multi provided token in lazy loaded module won't be visible to modules and services provided in root or in other lazy loaded chunks.
- 
-The easiest way to fix it is to always include such a code in a statically linked module, available upfront. We recommend creating a separate entry point in your library, by convention named _root_ (i.e. 'my-library/root') that contains minimal code that will be included in the main bundle and will be available from the beginning.
+The result is that any configuration or multi-provided token in a lazy-loaded module will not be visible to modules and services provided in the root, or in other lazy-loaded chunks.
 
-### Wrapping library code in lazy loaded module
+The easiest way to fix this is to always include this kind of code in a statically-linked module that is available upfront. It is recommended to create a separate entry point in your library (by convention, named _root_, such as `my-library/root`) that contains minimal code, and that will be included in the main bundle and will be available from the beginning.
 
-To address some specific customizations on top of a lazy loaded library, it's possible to wrap static imports from one or more libraries in one module that will be imported dynamically instead.
-This technique can be also an effective optimization strategy, as the builder will be able to use tree shaking for all the static imports inside the module.   
+### Wrapping Library Code in a Lazy-Loaded Module
 
+To address some specific customizations on top of a lazy loaded library, it is possible to wrap static imports from one or more libraries into a single module that will be imported dynamically instead. This technique can also be an effective optimization strategy, because the builder will be able to use tree shaking for all of the static imports inside the module.
 
-## Additional mechanisms (planned for Spartacus 3.0)
+## Additional Mechanisms (Planned for Spartacus 3.0)
 
 ### Unified Configuration
-_(preview available in 3.0-next releases)_
 
-Provides a way to get a global configuration that will include both root configuration + configuration from already loaded lazy loaded modules.
+_(A preview will be available in the 3.0-next releases)_
+
+Unified configuration provides a way to get a global configuration that includes both the root configuration and the configuration from already-loaded lazy-loaded modules.
 
 ### Unified Injector
-_(preview available in 3.0-next releases)_
 
-Provides a way to inject a token or multi provided tokens taking into and account root injector and injectors from lazy loaded modules.
-Injector exposes an Observable, that will emit each time status of the Unified Injector for specified token will change.
+_(A preview will be available in the 3.0-next releases)_
+
+The unified injector provides a way to inject a token, or multi-provided tokens, taking into account the root injector and the injectors from lazy-loaded modules. The injector exposes an Observable that emits a new set of injectables for a specified token each time the status of the Unified Injector changes. This status changes whenever Spartacus instantiates a new lazy-loaded module, because the module contains an injector that can be added to the Unified Injector.

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -193,12 +193,12 @@ To address some specific customizations on top of a lazy loaded library, it is p
 
 ### Unified Configuration
 
-_(A preview will be available in the 3.0-next releases)_
+**Note:** A preview will be available in the _3.0-next_ releases.
 
 Unified configuration provides a way to get a global configuration that includes both the root configuration and the configuration from already-loaded lazy-loaded modules.
 
 ### Unified Injector
 
-_(A preview will be available in the 3.0-next releases)_
+**Note:** A preview will be available in the _3.0-next_ releases.
 
 The unified injector provides a way to inject a token, or multi-provided tokens, taking into account the root injector and the injectors from lazy-loaded modules. The injector exposes an Observable that emits a new set of injectables for a specified token each time the status of the Unified Injector changes. This status changes whenever Spartacus instantiates a new lazy-loaded module, because the module contains an injector that can be added to the Unified Injector.

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -31,11 +31,13 @@ At the time of writing (Angular 9 and Angular 10), mixing static imports with dy
 
 ### Configuration in Lazy Loaded Modules
 
-The lazy loaded configuration is not visible to other modules and does not contribute to the global configuration of the running application. This will be addressed in Spartacus 3.x with the concept of unified configuration. For Spartacus 2.1, you should import modules with configuration statically.
+If additional configuration is provided inside the lazy-loaded module, this configuration is not merged in the global application configuration. As a result, the configuration will not affect any component other than the lazy-loaded components.
+
+This limitation will be addressed in Spartacus 3.x with the concept of unified configuration. For Spartacus 2.x, you should import modules with configuration statically.
 
 ### Providers in Lazy Loaded Modules
 
-Injection tokens provided in lazy-loaded modules are not visible to services provided in the app root. This applies especially to multi-provided tokens, such as `PageMetaResolvers`, various Handlers, and so on. This problem will be partially addressed in Spartacus 3.0 with the Unified Injector mechanism. For Spartacus 2.1, you should always provide these tokens in modules statically imported to your app root module.
+Injection tokens provided in lazy-loaded modules are not visible to services provided in the app root. This applies especially to multi-provided tokens, such as `PageMetaResolvers`, various Handlers, and so on. This problem will be partially addressed in Spartacus 3.0 with the Unified Injector mechanism. For Spartacus 2.x, you should always provide these tokens in modules statically imported to your app root module.
 
 ### Avoiding Importing the HttpClientModule in Your Lazy Loaded Modules
 

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -24,6 +24,8 @@ To meet those requirements, Spartacus provides CMS driven lazy loading on two le
 
 **Dynamic imports**, a technique used to facilitate lazy loading and allow for code splitting, can be only used in the main application. It's not possible to define them in prebuild libraries.
 
+This is an unfortunate limitation, that results in some application code that must be added by customers. While the amount of custom code is limited to the bare minimum, we'll add a feature in a future version of the schematics library to automatically add lazy loaded modules.
+
 ### Avoid static imports for lazy loaded code
 
 To make code spitting possible, your static javascript code (main app bundle) shouldn't have any static imports to code that you want to lazy load. The builder will notice, that the code is already included and won't generate a separate chunk for it.

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -9,7 +9,7 @@ title: Lazy Loading Guide
 As Spartacus is mostly CMS driven, there is not much of the usage of the built-in route based lazy loading offered by Angular out of the box. Code splitting has to be done at app build time, while Spartacus never knows upfront what components or features a specific route can contain, before actually loading them. 
 There is always a room for manual tweaking it based on app knowledge, but such a solution breaks the flexibility that Spartacus offers and requires additional prerequisites.
    
-To meet those requirements, Spartacus provides CMS driven lazy loading on two different layers:
+To meet those requirements, Spartacus provides CMS driven lazy loading on two levels:
  
    	1. Lazy loading of CMS components (simplest)
    	

--- a/_pages/dev/lazy-loading-guide.md
+++ b/_pages/dev/lazy-loading-guide.md
@@ -8,7 +8,7 @@ Such an approach can substantially improve "Time To Interactive", especially in 
 
 ## Spartacus Approach to Lazy Loading
 
-Spartacus is mostly CMS driven, which Spartacus does not use much of the built-in, route-based lazy loading that is offered out-of-the-box by Angular. Code splitting has to be done at app build time, although Spartacus cannot know what components or features a specific route can contain before actually loading them.
+Spartacus is mostly CMS driven, which means Spartacus does not use much of the built-in, route-based lazy loading that is offered out-of-the-box by Angular. Code splitting has to be done at app build time, although Spartacus cannot know what components or features a specific route can contain before actually loading them.
 
 As a result, Spartacus provides CMS-driven lazy loading in the following ways:
 
@@ -33,7 +33,7 @@ At the time of writing (Angular 9 and Angular 10), mixing static imports with dy
 
 ### Configuration in Lazy Loaded Modules
 
-The lazy loaded configuration is not be visible to other modules and does not contribute to the global configuration of the running application. This will be addressed in Spartacus 3.x with the concept of unified configuration. For Spartacus 2.1, you should import modules with configuration statically.
+The lazy loaded configuration is not visible to other modules and does not contribute to the global configuration of the running application. This will be addressed in Spartacus 3.x with the concept of unified configuration. For Spartacus 2.1, you should import modules with configuration statically.
 
 ### Providers in Lazy Loaded Modules
 


### PR DESCRIPTION
With the introduction of code splitting on components and modules, we like to describe the requirements for this process. While Spartacus will automate the creation of separate chunks (as an application code is required), we like to document this to share how it works, what is needed, and what can be split.