### PR TITLE
TUA Updated Installing SAP Commerce for use with TUA Spartacus for 1.0.0- Doc/gh 768

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,10 +31,12 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -237,6 +239,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.10-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -273,12 +277,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
     verbal_expressions (0.1.5)
     zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   github-pages

--- a/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
+++ b/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
@@ -32,7 +32,7 @@ Some of the steps in this procedure are derived from the documentation for insta
 
 1. Unzip the `b2ctelcospastore.zip` archive.
 
-1. Move the `b2ctelcospastore` folder to `sap-commerce-folder>/hybris/bin/modules/ b2c-telco-accelerator`.
+1. Move the `b2ctelcospastore` folder to `sap-commerce-folder>/hybris/bin/modules/b2c-telco-accelerator`.
 
    The `b2ctelcospastore` folder can be stored anywhere in the `modules` folder. The `b2c-telco-accelerator` folder is chosen as it contains other TUA sample data.
 

--- a/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
+++ b/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
@@ -49,7 +49,7 @@ Some of the steps in this procedure are derived from the documentation for insta
    def pl = platform {
 
        localProperties {
-	        	property 'kernel.events.cluster.jgroups.channel', 'disable'
+	        	  property 'kernel.events.cluster.jgroups.channel', 'disable'
 		        property 'datahub.publication.saveImpex', ''
 		        property 'commerceservices.default.desktop.ui.experience', 'responsive'
 		        property 'kernel.autoInitMode', 'update'
@@ -170,7 +170,7 @@ Some of the steps in this procedure are derived from the documentation for insta
    task startInBackground () {
 	      doLast {
 		         pl.startInBackground()
-	}
+	      }
    }
 
    task stopInBackground {
@@ -304,8 +304,7 @@ corsfilter.ycommercewebservices.allowedHeaders=origin content-type accept author
 ```
 
 ```sql
-corsfilter.b2ctelcotmfwebservices.allowedOrigins=http://localhost:4200
-https://localhost:4200
+corsfilter.b2ctelcotmfwebservices.allowedOrigins=http://localhost:4200 https://localhost:4200
 corsfilter.b2ctelcotmfwebservices.allowedMethods=GET HEAD OPTIONS PATCH PUT POST DELETE
 corsfilter.b2ctelcotmfwebservices.allowedHeaders=origin content-type accept authorization cache-control if-none-match x-anonymous-consents
 ```
@@ -368,6 +367,6 @@ This issue is caused by an incorrect configuration of the `sop.post.url` propert
 
 Make sure this property is set to `sop.post.url=https://localhost:9002/acceleratorservices/sop-mock/process`.
 
-**Note:** Please make sure that you have the website properties properly set for your `telcospa` base site to point to your environment. For your **localhost** environment they should have the following values: 
+**Note:** Please make sure that you have the website properties properly set for your `telcospa` base site to point to your environment. For your **localhost** environment, they should have the following values: 
 `website.telcospa.http=http://localhost:9001`
 `website.telcospa.https=https://localhost:9002`

--- a/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
+++ b/_pages/telco/installing-sap-commerce-for-tua-spartacus.md
@@ -4,7 +4,7 @@ title: Installing SAP Commerce for use with TUA Spartacus
 
 The following instructions describe how to install and configure SAP Commerce (release 1905) with Telco & Utilities Accelerator (release 2003, latest patch) for use with a TUA Spartacus storefront. In these instructions, SAP Commerce and Telco & Utilities Accelerator are installed on your local computer, so `localhost` is used in the browser URLs.
 
-The installation procedure includes steps for creating and using a `b2c_telco_spa` recipe that makes use of the TUA Spartacus Sample Data (`b2ctelcospastore`), but you can use you own sample data or recipe as long as it includes the `cmsoccaddon`, `ycommercewebservices`, `acceleratorwebservicesaddon` extensions and TUA module.
+The installation procedure includes steps for creating and using a `b2c_telco_spa` recipe that makes use of the TUA Spartacus Sample Data (`b2ctelcospastore`), but you can use your own sample data or recipe as long as it includes the `cmsoccaddon`, `ycommercewebservices`, `acceleratorwebservicesaddon` extensions and TUA module.
 
 **Note:** If you are trying out TUA Spartacus for the first time and intend to use the default sample data, you must use the TUA Spartacus Sample Data store extension (should be part of your list of extensions). The TUA Spartacus Sample Data is a set of data (product offerings and content) for the telco industry.
 


### PR DESCRIPTION
Please review the Installation topic updated for 1.1.0

[Installing SAP Commerce for use with TUA Spartacus - Spartacus Documentation.zip](https://github.com/SAP/spartacus-docs/files/5326690/Installing.SAP.Commerce.for.use.with.TUA.Spartacus.-.Spartacus.Documentation.zip)

