### PR TITLE
fix: Update selectiveCart confiuration

### DIFF
--- a/_pages/dev/features/selective-cart.md
+++ b/_pages/dev/features/selective-cart.md
@@ -1,9 +1,9 @@
 ---
 title: Selective Cart
 feature:
-  - name: Selective Cart
-    spa_version: 1.5
-    cx_version: 1905
+- name: Selective Cart
+  spa_version: 1.5
+  cx_version: 1905
 ---
 
 {% capture version_note %}
@@ -28,7 +28,7 @@ For more information, see [Selective Cart Architecture](https://help.sap.com/vie
 
 The Selective Cart feature has corresponding CMS-component data that allows you to enable or disable the feature. The configuration is provided in the `B2cStorefrontModule`.
 
-Furthermore, you need to configure the `selectiveCart` in cart configuration to enable or disable the feature. The following is an example:
+Furthermore, you need to configure the `selectiveCart` in the cart configuration to enable or disable the feature. The following is an example:
 
 ```typescript
 cart: {

--- a/_pages/dev/features/selective-cart.md
+++ b/_pages/dev/features/selective-cart.md
@@ -1,9 +1,9 @@
 ---
 title: Selective Cart
 feature:
-- name: Selective Cart
-  spa_version: 1.5
-  cx_version: 1905
+  - name: Selective Cart
+    spa_version: 1.5
+    cx_version: 1905
 ---
 
 {% capture version_note %}
@@ -28,23 +28,20 @@ For more information, see [Selective Cart Architecture](https://help.sap.com/vie
 
 The Selective Cart feature has corresponding CMS-component data that allows you to enable or disable the feature. The configuration is provided in the `B2cStorefrontModule`.
 
-Furthermore, you need to configure the `saveForLater` feature flag to enable or disable the feature. The following is an example:
+Furthermore, you need to configure the `selectiveCart` in cart configuration to enable or disable the feature. The following is an example:
 
 ```typescript
-features: {
-   saveForLater: true
+cart: {
+  selectiveCart: {
+    enabled: true,
+  }
 }
 ```
-
-For more information on feature flags and feature levels, see [Configuring Feature Flags]({{ site.baseurl }}{% link _pages/install/configuring-feature-flags.md %}).
-
 
 ## Configuring
 
 No special configuration is needed.
 
-
 ## Extending
 
 No special extensibility is available for this feature.
-


### PR DESCRIPTION
The documentation we already have for selective cart was correct for versions <2.0.
In 2.0 we moved the configuration for this feature to different place (https://github.com/SAP/spartacus/commit/103e3ae70ee8c732c0de00d023db40ddd52162ef)

Changes I reported here should be updated in spartacus version starting with the docs for 2.0 and are still up to date (no changes in 3.0).