### PR TITLE
fix: rename UrlService to SemanticPathService in routing docs

### DIFF
--- a/_pages/dev/routes/configurable-router-links.md
+++ b/_pages/dev/routes/configurable-router-links.md
@@ -271,7 +271,7 @@ routingService.go({ cxRoute: 'product', params: { productCode: 1234 } });
 
 ### Simply generation of the path
 
-The `UrlService.generateUrl` method called with `{ cxRoute: <route> }` returns the generated path (just like `cxUrl` pipe in HTML templates). For example:
+The `SemanticPathService.transform` method called with `{ cxRoute: <route> }` returns the generated path (just like `cxUrl` pipe in HTML templates). For example:
 
 When config is:
 
@@ -286,7 +286,7 @@ ConfigModule.withConfig({
 ```
 
 ```typescript
-urlService.generateUrl({ cxRoute: 'product', params: { productCode: 1234 } });
+semanticPathService.transform({ cxRoute: 'product', params: { productCode: 1234 } });
 
 // ['/', 'p', 1234]
 ```


### PR DESCRIPTION
Before releasing 1.0.0 we renamed UrlService to SemanticPathService in PR https://github.com/SAP/spartacus/pull/2515
We forgot to update the docs. Fixing it now.

fix #1022