### PR TITLE
Moved saved cart out of unsupported features

### DIFF
--- a/_pages/install/integrations/configurable-products-integration.md
+++ b/_pages/install/integrations/configurable-products-integration.md
@@ -60,7 +60,7 @@ This command uses schematics to modify your application and add the modules need
 ## Saved Cart
 
 {% capture version_note %}
-{{ site.version_note_part1 }} 3.3 {{ site.version_note_part2 }}
+{{ site.version_note_part1a }} 3.3 {{ site.version_note_part2 }}
 {% endcapture %}
 
 {% include docs/feature_version.html content=version_note %}


### PR DESCRIPTION
Saved cart is now supported and so removed this from the list of unsupported features

Closes #1127 