### PR TITLE
update frontend requirements for spartacus 4.x

### DIFF
--- a/_includes/docs/frontend_requirements.html
+++ b/_includes/docs/frontend_requirements.html
@@ -1,6 +1,9 @@
 <p>Your Angular development environment should include the following:</p>
 <ul>
     <li><a href="https://angular.io/">Angular CLI:</a> Version <strong>12.0.5</strong> or later, &lt; 13.</li>
-    <li><a href="https://nodejs.org/">Node.js:</a> The most recent <strong>12.x</strong> version is recommended, &lt; 13.</li>
+    <li><a href="https://nodejs.org/">Node.js:</a> The most recent <strong>14.x</strong> version is recommended.<sup>*</sup></li>
     <li><a href="https://classic.yarnpkg.com/">Yarn:</a> Version <strong>1.15</strong> or later.</li>
 </ul>
+<p>
+    <sup>*</sup> Node.js 12.x is <a href="https://nodejs.org/en/about/releases/">EOL by 2022-04-30</a>
+</p>


### PR DESCRIPTION
- Align the frontend requirements between [developer documentation](https://github.com/SAP/spartacus/#requirements) and public-facing docs
- strongly recommend Node 14, because 12 is dead soon
 