### PR TITLE
CMS components docs: Fix to show the interpolation  in html {{ data | json }}

### DIFF
--- a/_pages/dev/components/customizing-cms-components.md
+++ b/_pages/dev/components/customizing-cms-components.md
@@ -76,12 +76,14 @@ export class BannerComponent {
 }
 ```
 
+{% raw %}
 ```html
 <ng-container *ngIf="data$ | async as data">
   Access `data` here, for example:
   <pre>{{ data | json }}</pre>
 </ng-container>
 ```
+{% endraw %}
 
 ### Using Web Components as CMS Components (Experimental Support)
 


### PR DESCRIPTION
Content in `<pre>` was missing:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4001059/154225797-d83ff25e-8356-44b0-9461-e43cd4413e44.png">

<img width="302" alt="image" src="https://user-images.githubusercontent.com/4001059/154225726-2ca79176-c8b2-497b-97dc-99256cbbc062.png">

Now it's fixed