### PR TITLE
doc: CXSPA-9300 Adjust documentation for i18n lazy loading to use new 'public' path

### DIFF
--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -156,9 +156,7 @@ providers: [
 ];
 ```
 
-{% endraw %}
-
-**Note**: For Spartacus in version 2211.32 and below, the standard path for apps created by Angular CLI in version 17 is `src/assets` folder. The following is an example how to configure the `i18n.backend.loader` property for this case:
+**Note**: In Spartacus version 2211.32 or older, the standard path for apps created by version 17 of Angular CLI is `src/assets`, rather than `public`, which is used starting with Spartacus 2211.35. If you are using Spartacus version 2211.32 or older, the following is an example of how to configure the `i18n.backend.loader` property:
 
 ```typescript
 providers: [
@@ -174,8 +172,9 @@ providers: [
 ];
 ```
 
+{% endraw %}
 
-In the above example, the function is configured to return a **Promise** (in this case, an ES dynamic import) with the translation chunk. The ES dynamic import feature allows you to split the JSON files from the main JS bundle and have them loaded by Webpack only when needed. During the build process, Webpack wraps the JSON files into JS files. The following image from the Chrome DevTools **Network** tab shows the sample compiled JSON files loaded in the browser:
+In both of the above examples, the function is configured to return a **Promise** (in this case, an ES dynamic import) with the translation chunk. The ES dynamic import feature allows you to split the JSON files from the main JS bundle and have them loaded by Webpack only when needed. During the build process, Webpack wraps the JSON files into JS files. The following image from the Chrome DevTools **Network** tab shows the sample compiled JSON files loaded in the browser:
 
 ![Chrome DevTools Network tab: JSON translations development build](https://user-images.githubusercontent.com/4001059/216402373-f981eca1-48d5-40a4-b265-ecc11633426f.png)
 
@@ -220,7 +219,8 @@ cp ./node_modules/@spartacus/assets/i18n-assets ./public -r
 
 **Note**: None of the feature libraries, such as `@spartacus/cart` or `@spartacus/checkout`, have the predefined JSON files with translations exported. If you want to use them, you need to create them manually. To track this issue, see [GitHub issue #9186](https://github.com/SAP/spartacus/issues/9186).
 
-**Note**: For Spartacus in version 2211.32 and below, the standard path for apps created by Angular CLI in version 17 is `src/assets` folder. The following is an example how to copy the predefined JSON files to the `src/assets` folder:
+**Note**: In Spartacus version 2211.32 or older, the standard path for apps created by version 17 of Angular CLI is `src/assets`. The following is an example of how to copy the predefined JSON files to the `src/assets` folder:
+
 ```bash
 cp ./node_modules/@spartacus/assets/i18n-assets ./src/assets -r
 ```

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -148,7 +148,7 @@ providers: [
     i18n: {
       backend: {
         loader: (lng: string, ns: string) =>
-          import(`../../assets/i18n-assets/${lng}/${ns}.json`),
+          import(`../../../public/i18n-assets/${lng}/${ns}.json`),
         chunks: translationChunksConfig,
       },
     },
@@ -157,6 +157,23 @@ providers: [
 ```
 
 {% endraw %}
+
+**Note**: For Spartacus in version 2211.32 and below, the standard path for apps created by Angular CLI in version 17 is `src/assets` folder. The following is an example how to configure the `i18n.backend.loader` property for this case:
+
+```typescript
+providers: [
+  provideConfig({
+    i18n: {
+      backend: {
+        loader: (lng: string, ns: string) =>
+          import(`../../assets/i18n-assets/${lng}/${ns}.json`),
+        chunks: translationChunksConfig,
+      },
+    },
+  }),
+];
+```
+
 
 In the above example, the function is configured to return a **Promise** (in this case, an ES dynamic import) with the translation chunk. The ES dynamic import feature allows you to split the JSON files from the main JS bundle and have them loaded by Webpack only when needed. During the build process, Webpack wraps the JSON files into JS files. The following image from the Chrome DevTools **Network** tab shows the sample compiled JSON files loaded in the browser:
 
@@ -189,19 +206,24 @@ providers: [
 
 {% endraw %}
 
-It is theoretically possible to use a local path (without `https://...`) for `loadPath`, such as {% raw %}`'assets/i18n-assets/{{lng}}/{{ns}}.json'`{% endraw %}. However, this is **not recommended** in SSR because it causes translations to be loaded through HTTP requests, which results in unnecessary HTTP round trips from SSR to the `ExpressJS` server itself. For better performance in SSR, it is recommended that you use a dynamic import in the `i18n.backend.loader` config, as described in the section above.
+It is theoretically possible to use a local path (without `https://...`) for `loadPath`, such as {% raw %}`'public/i18n-assets/{{lng}}/{{ns}}.json'`{% endraw %}. However, this is **not recommended** in SSR because it causes translations to be loaded through HTTP requests, which results in unnecessary HTTP round trips from SSR to the `ExpressJS` server itself. For better performance in SSR, it is recommended that you use a dynamic import in the `i18n.backend.loader` config, as described in the section above.
 
 ### Predefined JSON Translation Assets
 
 For Spartacus, you can find the predefined JSON files with translations in the `/i18n-assets` folder of `@spartacus/assets`. You need to serve these files, either from your own custom endpoint, or by copying them into the `/assets` folder of your Angular application. The following is an example:
 
 ```bash
-cp ./node_modules/@spartacus/assets/i18n-assets ./src/assets -r
+cp ./node_modules/@spartacus/assets/i18n-assets ./public -r
 ```
 
-**Note**: The `./src/assets` path shown in this example is a standard path for apps created by Angular CLI. Your path to assets may be different.
+**Note**: The `./public` path shown in this example is a standard path for apps created by Angular CLI. Your path to assets may be different.
 
 **Note**: None of the feature libraries, such as `@spartacus/cart` or `@spartacus/checkout`, have the predefined JSON files with translations exported. If you want to use them, you need to create them manually. To track this issue, see [GitHub issue #9186](https://github.com/SAP/spartacus/issues/9186).
+
+**Note**: For Spartacus in version 2211.32 and below, the standard path for apps created by Angular CLI in version 17 is `src/assets` folder. The following is an example how to copy the predefined JSON files to the `src/assets` folder:
+```bash
+cp ./node_modules/@spartacus/assets/i18n-assets ./src/assets -r
+```
 
 ### Deciding When to Create a New Chunk
 


### PR DESCRIPTION
closes [CXSPA-9300](https://jira.tools.sap/browse/CXSPA-9300)