### PR TITLE
doc: use new En-suffixed translations objects in a wrapper object `{ en: ... }`

### DIFF
--- a/_pages/contributing/contributor-setup.md
+++ b/_pages/contributing/contributor-setup.md
@@ -190,7 +190,7 @@ To configure the storefront, use the `provideConfig` method from `@spartacus/cor
     provideConfig(<I18nConfig>{
       // we bring in static translations to be up and running soon right away
       i18n: {
-        resources: translations,
+        resources: { en: translationsEn },
         chunks: translationChunksConfig,
         fallbackLang: 'en',
       },

--- a/_pages/contributing/contributor-setup.md
+++ b/_pages/contributing/contributor-setup.md
@@ -190,7 +190,8 @@ To configure the storefront, use the `provideConfig` method from `@spartacus/cor
     provideConfig(<I18nConfig>{
       // we bring in static translations to be up and running soon right away
       i18n: {
-        resources: { en: translationsEn },
+        resources: { en: translationsEn }, // Use with version 2211.35 or newer
+    //  resources: translations, // Use with version 2211.32.1 or older
         chunks: translationChunksConfig,
         fallbackLang: 'en',
       },

--- a/_pages/dev/features/b2b-commerce-organization.md
+++ b/_pages/dev/features/b2b-commerce-organization.md
@@ -423,7 +423,8 @@ Organization translation resources can be overridden following the same rules as
 ```ts
 provideConfig({
   i18n: {
-    resources: { en: organizationTranslationsEn },
+    resources: { en: organizationTranslationsEn }, // Use with version 2211.35 or newer
+//  resources: organizationTranslations, // Use with version 2211.32.1 or older
     chunks: organizationTranslationChunksConfig,
   },
 }),

--- a/_pages/dev/features/b2b-commerce-organization.md
+++ b/_pages/dev/features/b2b-commerce-organization.md
@@ -423,7 +423,7 @@ Organization translation resources can be overridden following the same rules as
 ```ts
 provideConfig({
   i18n: {
-    resources: organizationTranslations,
+    resources: { en: organizationTranslationsEn },
     chunks: organizationTranslationChunksConfig,
   },
 }),

--- a/_pages/dev/features/product-multi-dimensional.md
+++ b/_pages/dev/features/product-multi-dimensional.md
@@ -123,7 +123,7 @@ You can configure the translations for the multi-dimensional selector. For examp
 ```ts
     provideConfig({
     i18n: {
-        resources: multiDimensionalSelectorTranslations,
+        resources: { en: multiDimensionalSelectorTranslationsEn },
         chunks: multiDimensionalSelectorTranslationChunksConfig,
         fallbackLang: 'en',
     },
@@ -164,7 +164,7 @@ You can then add this in the feature module, as shown in the following example:
                 },
             },
             i18n: {
-                resources: multiDimensionalSelectorTranslations,
+                resources: { en: multiDimensionalSelectorTranslationsEn },
                 chunks: multiDimensionalSelectorTranslationChunksConfig,
                 fallbackLang: 'en',
             },

--- a/_pages/dev/features/product-multi-dimensional.md
+++ b/_pages/dev/features/product-multi-dimensional.md
@@ -123,7 +123,8 @@ You can configure the translations for the multi-dimensional selector. For examp
 ```ts
     provideConfig({
     i18n: {
-        resources: { en: multiDimensionalSelectorTranslationsEn },
+        resources: { en: multiDimensionalSelectorTranslationsEn }, // Use with version 2211.35 or newer
+    //  resources: multiDimensionalSelectorTranslations, // Use with version 2211.32.1 or older
         chunks: multiDimensionalSelectorTranslationChunksConfig,
         fallbackLang: 'en',
     },
@@ -164,7 +165,8 @@ You can then add this in the feature module, as shown in the following example:
                 },
             },
             i18n: {
-                resources: { en: multiDimensionalSelectorTranslationsEn },
+                resources: { en: multiDimensionalSelectorTranslationsEn }, // Use with version 2211.35 or newer
+            //  resources: multiDimensionalSelectorTranslations, // Use with version 2211.32.1 or older
                 chunks: multiDimensionalSelectorTranslationChunksConfig,
                 fallbackLang: 'en',
             },

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -22,14 +22,14 @@ Spartacus uses the `i18next` library for its translation mechanism, and uses  `i
 For a quick start, import the predefined Spartacus translations (currently only in English) from `@spartacus/assets`, and register them with `provideConfig`. The following is an example:
 
 ```typescript
-import { translations, translationChunksConfig } from '@spartacus/assets';
+import { translationsEn , translationChunksConfig } from '@spartacus/assets';
 
 // ...
 
 providers: [
   provideConfig({
     i18n: {
-      resources: translations,
+      resources: { en: translationsEn },
       chunks: translationChunksConfig,
     },
   }),
@@ -41,7 +41,7 @@ providers: [
 Instead of using the predefined Spartacus translations, you can provide your own English translations, and add translations for other languages as well. The following is an example:
 
 ```typescript
-import { translations, translationChunksConfig } from '@spartacus/assets';
+import { translationsEn , translationChunksConfig } from '@spartacus/assets';
 
 // ...
 
@@ -49,7 +49,7 @@ providers: [
   provideConfig({
     i18n: {
         resources: {
-            en: translations, // or YOUR_ENGLISH_TRANSLATIONS,
+            en: translationsEn, // or YOUR_ENGLISH_TRANSLATIONS,
             de: YOUR_GERMAN_TRANSLATIONS,
             ...
         },
@@ -68,7 +68,7 @@ To overwrite individual translations, the object with overwrites needs to be pro
 ```typescript
 // spartacus-configuration.module
 
-import { translations } from '@spartacus/assets';
+import { translationsEn } from '@spartacus/assets';
 
 // ...
 
@@ -86,7 +86,7 @@ export const translationOverwrites = {
 
 providers: [
   provideConfig({
-    i18n: { resources: translations },
+    i18n: { resources: { en: translationsEn } },
   }),
   provideConfig({
     i18n: { resources: translationOverwrites },
@@ -105,14 +105,14 @@ To provide better a better user experience if a translation is missing, you can 
 The following is an example configuration with English as a fallback language:
 
 ```typescript
-import { translations, translationChunksConfig } from '@spartacus/assets';
+import { translationsEn, translationChunksConfig } from '@spartacus/assets';
 
 // ...
 
 providers: [
   provideConfig({
     i18n: {
-      resources: translations,
+      resources: { en: translationsEn } ,
       chunks: translationChunksConfig,
       fallbackLang: 'en',
     },

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -22,14 +22,16 @@ Spartacus uses the `i18next` library for its translation mechanism, and uses  `i
 For a quick start, import the predefined Spartacus translations (currently only in English) from `@spartacus/assets`, and register them with `provideConfig`. The following is an example:
 
 ```typescript
-import { translationsEn , translationChunksConfig } from '@spartacus/assets';
+import { translationsEn , translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
+// import { translations, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
 
 providers: [
   provideConfig({
     i18n: {
-      resources: { en: translationsEn },
+      resources: { en: translationsEn }, // Use with version 2211.35 or newer
+  //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
     },
   }),
@@ -41,7 +43,8 @@ providers: [
 Instead of using the predefined Spartacus translations, you can provide your own English translations, and add translations for other languages as well. The following is an example:
 
 ```typescript
-import { translationsEn , translationChunksConfig } from '@spartacus/assets';
+import { translationsEn , translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
+// import { translations, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
 
@@ -49,7 +52,8 @@ providers: [
   provideConfig({
     i18n: {
         resources: {
-            en: translationsEn, // or YOUR_ENGLISH_TRANSLATIONS,
+            en: translationsEn, // or YOUR_ENGLISH_TRANSLATIONS, (Use 'translationsEn' with version 2211.35 or newer)
+        //  en: translations, // or YOUR_ENGLISH_TRANSLATIONS, (Use 'translations' with version 2211.32.1 or older)
             de: YOUR_GERMAN_TRANSLATIONS,
             ...
         },
@@ -68,7 +72,8 @@ To overwrite individual translations, the object with overwrites needs to be pro
 ```typescript
 // spartacus-configuration.module
 
-import { translationsEn } from '@spartacus/assets';
+import { translationsEn } from '@spartacus/assets'; // Use with version 2211.35 or newer
+// import { translations } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
 
@@ -86,7 +91,8 @@ export const translationOverwrites = {
 
 providers: [
   provideConfig({
-    i18n: { resources: { en: translationsEn } },
+    i18n: { resources: { en: translationsEn } }, // Use with version 2211.35 or newer
+//  i18n: { resources: translations }, // Use with version 2211.32.1 or older
   }),
   provideConfig({
     i18n: { resources: translationOverwrites },
@@ -105,14 +111,16 @@ To provide better a better user experience if a translation is missing, you can 
 The following is an example configuration with English as a fallback language:
 
 ```typescript
-import { translationsEn, translationChunksConfig } from '@spartacus/assets';
+import { translationsEn, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
+// import { translations, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
 
 providers: [
   provideConfig({
     i18n: {
-      resources: { en: translationsEn } ,
+      resources: { en: translationsEn } , // Use with version 2211.35 or newer
+  //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
       fallbackLang: 'en',
     },

--- a/_pages/install/integrations/digital-payments-integration.md
+++ b/_pages/install/integrations/digital-payments-integration.md
@@ -70,7 +70,7 @@ Perform the following steps after you have set up your Spartacus Storefront. For
    import { CmsConfig, I18nConfig, provideConfig } from '@spartacus/core';
    import {
      dpTranslationChunksConfig,
-     dpTranslations,
+     dpTranslationsEn,
    } from '@spartacus/digital-payments/assets';
    @NgModule({
      providers: [
@@ -86,7 +86,7 @@ Perform the following steps after you have set up your Spartacus Storefront. For
        }),
        provideConfig(<I18nConfig>{
          i18n: {
-           resources: dpTranslations,
+           resources: { en: dpTranslationsEn },
            chunks: dpTranslationChunksConfig,
            fallbackLang: 'en',
          },
@@ -181,7 +181,7 @@ Perform the following steps after you have set up your Spartacus Storefront. For
    ```ts
    import { NgModule } from '@angular/core';
    import { I18nConfig, provideConfig } from "@spartacus/core";
-   import { DigitalPaymentsModule, dpTranslationChunksConfig, dpTranslations } from "@spartacus/digital-payments";
+   import { DigitalPaymentsModule, dpTranslationChunksConfig, dpTranslationsEn } from "@spartacus/digital-payments";
    
    @NgModule({
      declarations: [],
@@ -190,7 +190,7 @@ Perform the following steps after you have set up your Spartacus Storefront. For
      ],
      providers: [provideConfig(<I18nConfig>{
        i18n: {
-         resources: dpTranslations,
+         resources: dpTranslationsEn,
          chunks: dpTranslationChunksConfig,
        },
      })]

--- a/_pages/install/integrations/digital-payments-integration.md
+++ b/_pages/install/integrations/digital-payments-integration.md
@@ -70,7 +70,8 @@ Perform the following steps after you have set up your Spartacus Storefront. For
    import { CmsConfig, I18nConfig, provideConfig } from '@spartacus/core';
    import {
      dpTranslationChunksConfig,
-     dpTranslationsEn,
+     dpTranslationsEn, // Use with version 2211.35 or newer
+  //  dpTranslations, // Use with version 2211.32.1 or older
    } from '@spartacus/digital-payments/assets';
    @NgModule({
      providers: [
@@ -86,7 +87,8 @@ Perform the following steps after you have set up your Spartacus Storefront. For
        }),
        provideConfig(<I18nConfig>{
          i18n: {
-           resources: { en: dpTranslationsEn },
+           resources: { en: dpTranslationsEn }, // Use with version 2211.35 or newer
+       //  resources: dpTranslations, // Use with version 2211.32.1 or older
            chunks: dpTranslationChunksConfig,
            fallbackLang: 'en',
          },
@@ -181,7 +183,8 @@ Perform the following steps after you have set up your Spartacus Storefront. For
    ```ts
    import { NgModule } from '@angular/core';
    import { I18nConfig, provideConfig } from "@spartacus/core";
-   import { DigitalPaymentsModule, dpTranslationChunksConfig, dpTranslationsEn } from "@spartacus/digital-payments";
+   import { DigitalPaymentsModule, dpTranslationChunksConfig, dpTranslationsEn } from "@spartacus/digital-payments"; // Use with version 2211.35 or newer
+   // import { DigitalPaymentsModule, dpTranslationChunksConfig, dpTranslations } from "@spartacus/digital-payments"; // Use with version 2211.32.1 or older
    
    @NgModule({
      declarations: [],
@@ -190,7 +193,8 @@ Perform the following steps after you have set up your Spartacus Storefront. For
      ],
      providers: [provideConfig(<I18nConfig>{
        i18n: {
-         resources: dpTranslationsEn,
+         resources: dpTranslationsEn, // Use with version 2211.35 or newer
+     //  resources: dpTranslations, // Use with version 2211.32.1 or older
          chunks: dpTranslationChunksConfig,
        },
      })]

--- a/_pages/install/integrations/epd-visualization-integration.md
+++ b/_pages/install/integrations/epd-visualization-integration.md
@@ -83,7 +83,7 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
    import { NgModule } from '@angular/core';
    import { I18nConfig, provideConfig } from "@spartacus/core";
    import { EpdVisualizationModule } from "@spartacus/epd-visualization";
-   import { epdVisualizationTranslationChunksConfig, epdVisualizationTranslations } from "@spartacus/epd-visualization/assets";
+   import { epdVisualizationTranslationChunksConfig, epdVisualizationTranslationsEn } from "@spartacus/epd-visualization/assets";
    import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/epd-visualization/root";
 
    @NgModule({
@@ -94,7 +94,7 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
      ],
      providers: [provideConfig(<I18nConfig>{
        i18n: {
-         resources: epdVisualizationTranslations,
+         resources: epdVisualizationTranslationsEn,
          chunks: epdVisualizationTranslationChunksConfig,
        },
      }),
@@ -131,7 +131,7 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
 
    ```typescript
    import { NgModule } from '@angular/core';
-   import { translationChunksConfig, translations } from "@spartacus/assets";
+   import { translationChunksConfig, translationsEn } from "@spartacus/assets";
    import { FeaturesConfig, I18nConfig, OccConfig, provideConfig, SiteContextConfig } from "@spartacus/core";
    import { defaultB2bCheckoutConfig, defaultB2bOccConfig } from "@spartacus/setup";
    import { defaultCmsContentProviders, layoutConfig, mediaConfig } from "@spartacus/storefront";
@@ -154,7 +154,7 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
        },
      }), provideConfig(<I18nConfig>{
        i18n: {
-         resources: translations,
+         resources: { en: translationsEn },
          chunks: translationChunksConfig,
          fallbackLang: 'en'
        },

--- a/_pages/install/integrations/epd-visualization-integration.md
+++ b/_pages/install/integrations/epd-visualization-integration.md
@@ -83,7 +83,8 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
    import { NgModule } from '@angular/core';
    import { I18nConfig, provideConfig } from "@spartacus/core";
    import { EpdVisualizationModule } from "@spartacus/epd-visualization";
-   import { epdVisualizationTranslationChunksConfig, epdVisualizationTranslationsEn } from "@spartacus/epd-visualization/assets";
+   import { epdVisualizationTranslationChunksConfig, epdVisualizationTranslationsEn } from "@spartacus/epd-visualization/assets"; // Use with version 2211.35 or newer
+   // import { epdVisualizationTranslationChunksConfig, epdVisualizationTranslations } from "@spartacus/epd-visualization/assets"; // Use with version 2211.32.1 or older
    import { EpdVisualizationConfig, EpdVisualizationRootModule } from "@spartacus/epd-visualization/root";
 
    @NgModule({
@@ -94,7 +95,8 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
      ],
      providers: [provideConfig(<I18nConfig>{
        i18n: {
-         resources: epdVisualizationTranslationsEn,
+         resources: epdVisualizationTranslationsEn, // Use with version 2211.35 or newer
+     //  resources: epdVisualizationTranslations, // Use with version 2211.32.1 or older
          chunks: epdVisualizationTranslationChunksConfig,
        },
      }),
@@ -131,7 +133,8 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
 
    ```typescript
    import { NgModule } from '@angular/core';
-   import { translationChunksConfig, translationsEn } from "@spartacus/assets";
+   import { translationChunksConfig, translationsEn } from "@spartacus/assets"; // Use with version 2211.35 or newer
+   // import { translationChunksConfig, translations } from "@spartacus/assets"; // Use with version 2211.32.1 or older
    import { FeaturesConfig, I18nConfig, OccConfig, provideConfig, SiteContextConfig } from "@spartacus/core";
    import { defaultB2bCheckoutConfig, defaultB2bOccConfig } from "@spartacus/setup";
    import { defaultCmsContentProviders, layoutConfig, mediaConfig } from "@spartacus/storefront";
@@ -154,7 +157,8 @@ If you do not wish to use the schematics, you can manually add the SAP Enterpris
        },
      }), provideConfig(<I18nConfig>{
        i18n: {
-         resources: { en: translationsEn },
+         resources: { en: translationsEn }, // Use with version 2211.35 or newer
+     //  resources: translations, // Use with version 2211.32.1 or older
          chunks: translationChunksConfig,
          fallbackLang: 'en'
        },

--- a/_pages/install/reference-app-structure.md
+++ b/_pages/install/reference-app-structure.md
@@ -162,7 +162,7 @@ import { StoreFinderRootModule } from '@spartacus/storefinder/root';
 import { provideConfig } from '@spartacus/core';
 import {
   storeFinderTranslationChunksConfig,
-  storeFinderTranslations,
+  storeFinderTranslationsEn,
 } from '@spartacus/storefinder/assets';
 
 @NgModule({
@@ -176,7 +176,7 @@ import {
         },
       },
       i18n: {
-        resources: storeFinderTranslations,
+        resources: { en: storeFinderTranslationsEn },
         chunks: storeFinderTranslationChunksConfig,
       },
     }),

--- a/_pages/install/reference-app-structure.md
+++ b/_pages/install/reference-app-structure.md
@@ -162,7 +162,8 @@ import { StoreFinderRootModule } from '@spartacus/storefinder/root';
 import { provideConfig } from '@spartacus/core';
 import {
   storeFinderTranslationChunksConfig,
-  storeFinderTranslationsEn,
+  storeFinderTranslationsEn, // Use with version 2211.35 or newer
+// storeFinderTranslations, // Use with version 2211.32.1 or older
 } from '@spartacus/storefinder/assets';
 
 @NgModule({
@@ -176,7 +177,8 @@ import {
         },
       },
       i18n: {
-        resources: { en: storeFinderTranslationsEn },
+        resources: { en: storeFinderTranslationsEn }, // Use with version 2211.35 or newer
+    //  resources: storeFinderTranslations, // Use with version 2211.32.1 or older
         chunks: storeFinderTranslationChunksConfig,
       },
     }),


### PR DESCRIPTION
fixes https://jira.tools.sap/browse/CXSPA-9209