### PR TITLE
doc: use NG_ALLOWED_HOSTS=localhost, when serving locally a SSR build - since ng21.2.0 / ng19.2.21

### DIFF
--- a/_pages/contributing/contributor-setup.md
+++ b/_pages/contributing/contributor-setup.md
@@ -153,6 +153,8 @@ npm run start:prod
    npm run serve:ssr
    ```
 
+**Note**: if you serve the production SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
+
 The app will be served with the production build, without using the webpack dev server. As a result, PWA and the features related to service workers will be fully functional.
 
 ## Additional Storefront Configuration

--- a/_pages/contributing/contributor-setup.md
+++ b/_pages/contributing/contributor-setup.md
@@ -153,7 +153,7 @@ npm run start:prod
    npm run serve:ssr
    ```
 
-**Note**: if you serve the production SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
+**Note**: if you serve the SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
 
 The app will be served with the production build, without using the webpack dev server. As a result, PWA and the features related to service workers will be fully functional.
 

--- a/_pages/contributing/contributor-setup.md
+++ b/_pages/contributing/contributor-setup.md
@@ -153,7 +153,13 @@ npm run start:prod
    npm run serve:ssr
    ```
 
-**Note**: if you serve the SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
+**Note**: If you serve the SSR build on `localhost`, you need to allowlist it. For example, you can allowlist `localhost` with a special env variable when you run the `npm run serve:ssr` command, as shown in the following example:
+
+```bash
+NG_ALLOWED_HOSTS=localhost npm run serve:ssr
+```
+
+Allowlisting the `localhost` is required since the release of Angular security patches `19.2.21+` and `21.2.0+`. For more information about this requirement, see the [official Angular documentation](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
 
 The app will be served with the production build, without using the webpack dev server. As a result, PWA and the features related to service workers will be fully functional.
 

--- a/_pages/dev/ssr/server-side-rendering-in-spartacus.md
+++ b/_pages/dev/ssr/server-side-rendering-in-spartacus.md
@@ -387,3 +387,5 @@ If you are involved in Spartacus internal development (for example, if you are c
    ```bash
    npm run serve:ssr
    ```
+
+**Note**: if you serve the production SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).

--- a/_pages/dev/ssr/server-side-rendering-in-spartacus.md
+++ b/_pages/dev/ssr/server-side-rendering-in-spartacus.md
@@ -388,4 +388,10 @@ If you are involved in Spartacus internal development (for example, if you are c
    npm run serve:ssr
    ```
 
-**Note**: if you serve the SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
+**Note**: If you serve the SSR build on `localhost`, you need to allowlist it. For example, you can allowlist `localhost` with a special env variable when you run the `npm run serve:ssr` command, as shown in the following example:
+
+```bash
+NG_ALLOWED_HOSTS=localhost npm run serve:ssr
+```
+
+Allowlisting the `localhost` is required since the release of Angular security patches `19.2.21+` and `21.2.0+`. For more information about this requirement, see the [official Angular documentation](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).

--- a/_pages/dev/ssr/server-side-rendering-in-spartacus.md
+++ b/_pages/dev/ssr/server-side-rendering-in-spartacus.md
@@ -388,4 +388,4 @@ If you are involved in Spartacus internal development (for example, if you are c
    npm run serve:ssr
    ```
 
-**Note**: if you serve the production SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).
+**Note**: if you serve the SSR build on `localhost`, you need allow-list it, e.g. with a special env variable `NG_ALLOWED_HOSTS=localhost npm run serve:ssr`. It's needed since the Angular security patch releases v19.2.21+ and v21.2.0+. For more options, see [Angular docs](https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf).


### PR DESCRIPTION
related fix in our own monorepo https://github.com/SAP/spartacus/pull/21214