### PR TITLE
i18n: change .ts to .json and use inject() instead of constructor

### DIFF
--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -467,7 +467,7 @@ The translation is observable, so you must also add an `async` pipe to the templ
 
 In components, it is a best practice to use the `cxTranslate` pipe in the HTML template pipe, rather than the `TranslationService` in the TypeScript logic, unless there is a strong reason for using `TranslationService`.
 
-The disadvantage of using `TranslationService`: it might introduce unnecessary methods and RxJs Observable logic to the component TypeScript class
+The disadvantage of using `TranslationService` is that it might introduce unnecessary methods and RxJs Observable logic to the component TypeScript class.
 
 ## Upgrading
 

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -4,25 +4,25 @@ title: Internationalization (i18n)
 
 In a typical Spartacus storefront, most of the content comes either from the CMS, or from the product content. However, for the storefront site labels (such as texts in buttons), the content is stored in separate files, and these can be localized (that is, translated).
 
----
+***
 
 **Table of Contents**
 
 - This will become a table of contents (this text will be scrapped).
-  {:toc}
+{:toc}
 
----
+***
 
 ## Dependencies
 
-Spartacus uses the `i18next` library for its translation mechanism, and uses `i18next-http-backend` for lazy loading of translation chunks. Both of these libraries have rich APIs, but Spartacus supports only parts of them, and treats them as implementation details. As a result, Spartacus does not support custom usage of `i18next` in your application.
+Spartacus uses the `i18next` library for its translation mechanism, and uses  `i18next-http-backend` for lazy loading of translation chunks. Both of these libraries have rich APIs, but Spartacus supports only parts of them, and treats them as implementation details. As a result, Spartacus does not support custom usage of `i18next` in your application.
 
 ## Getting Started
 
 For a quick start, import the predefined Spartacus translations (currently only in English) from `@spartacus/assets`, and register them with `provideConfig`. The following is an example:
 
 ```typescript
-import { translationsEn, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
+import { translationsEn , translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
 // import { translations, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
@@ -31,7 +31,7 @@ providers: [
   provideConfig({
     i18n: {
       resources: { en: translationsEn }, // Use with version 2211.35 or newer
-      //  resources: translations, // Use with version 2211.32.1 or older
+  //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
     },
   }),
@@ -78,12 +78,9 @@ import { translationsEn } from '@spartacus/assets'; // Use with version 2211.35 
 // ...
 
 export const translationOverwrites = {
-  en: {
-    // lang
-    cart: {
-      // chunk
-      cartDetails: {
-        // keys (nested)
+  en: { // lang
+    cart: { // chunk
+      cartDetails: { // keys (nested)
         proceedToCheckout: 'Proceed to Checkout',
       },
     },
@@ -95,7 +92,7 @@ export const translationOverwrites = {
 providers: [
   provideConfig({
     i18n: { resources: { en: translationsEn } }, // Use with version 2211.35 or newer
-    //  i18n: { resources: translations }, // Use with version 2211.32.1 or older
+//  i18n: { resources: translations }, // Use with version 2211.32.1 or older
   }),
   provideConfig({
     i18n: { resources: translationOverwrites },
@@ -122,8 +119,8 @@ import { translationsEn, translationChunksConfig } from '@spartacus/assets'; // 
 providers: [
   provideConfig({
     i18n: {
-      resources: { en: translationsEn }, // Use with version 2211.35 or newer
-      //  resources: translations, // Use with version 2211.32.1 or older
+      resources: { en: translationsEn } , // Use with version 2211.35 or newer
+  //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
       fallbackLang: 'en',
     },
@@ -149,7 +146,7 @@ interface TranslationResources {
 
 The `i18n.backend.loader` config property is introduced with Spartacus 6.1 and is recommended for better SSR performance, compared to the older `i18n.backend.loadPath` config property. The older `i18n.backend.loadPath` config property should only be used when storing translations in a remote endpoint.
 
-To enable lazy loading of JSON translation assets stored in a local project, configure the `i18n.backend.loader` property as a function that returns a `Promise` with the translation chunk for the given language and chunk name. The following is an example:
+To enable lazy loading of JSON translation assets stored in a local project, configure the `i18n.backend.loader` property as a function  that returns a `Promise` with the translation chunk for the given language and chunk name. The following is an example:
 
 {% raw %}
 
@@ -331,7 +328,6 @@ chunks: [
 You can also pass parameters into the translation pipe, for example:
 
 {% raw %}
-
 ```html
 <p>{{ 'miniLogin.hello' | cxTranslate : { name: person.name } }}</p>
 ```
@@ -339,12 +335,11 @@ You can also pass parameters into the translation pipe, for example:
 ```ts
 // resources
 {
-  miniLogin: {
-    hello: 'Hello, {{ name }}';
-  }
+    miniLogin: {
+        hello: 'Hello, {{ name }}'
+    }
 }
 ```
-
 {% endraw %}
 
 ### Special Parameter: count
@@ -465,7 +460,9 @@ getPaymentCardContent(payment: PaymentDetails): Observable<Card> {
 The translation is observable, so you must also add an `async` pipe to the template. The following is an example:
 
 ```html
-<cx-card [content]="getPaymentCardContent(order.paymentInfo) | async"></cx-card>
+<cx-card
+    [content]="getPaymentCardContent(order.paymentInfo) | async"
+></cx-card>
 ```
 
 ### Best Practices
@@ -528,6 +525,7 @@ The `cxDate` pipe is just a wrapper of Angular's `date` pipe, so it accepts the 
 **Note**: The `cxDate` pipe uses Angular's locale data, which only comes with English by default. For other locales, you need to register them explicitly in your app.module. The following is an example from the app.module:
 
 ```typescript
+
 import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 
@@ -561,7 +559,7 @@ To prevent injection attacks through translations, ensure that escaping is enabl
 providers: [
   provideConfig({
     i18n: {
-        ...
+        ... 
       interpolation: {
         escapeValue: true,
       }

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -4,25 +4,25 @@ title: Internationalization (i18n)
 
 In a typical Spartacus storefront, most of the content comes either from the CMS, or from the product content. However, for the storefront site labels (such as texts in buttons), the content is stored in separate files, and these can be localized (that is, translated).
 
-***
+---
 
 **Table of Contents**
 
 - This will become a table of contents (this text will be scrapped).
-{:toc}
+  {:toc}
 
-***
+---
 
 ## Dependencies
 
-Spartacus uses the `i18next` library for its translation mechanism, and uses  `i18next-http-backend` for lazy loading of translation chunks. Both of these libraries have rich APIs, but Spartacus supports only parts of them, and treats them as implementation details. As a result, Spartacus does not support custom usage of `i18next` in your application.
+Spartacus uses the `i18next` library for its translation mechanism, and uses `i18next-http-backend` for lazy loading of translation chunks. Both of these libraries have rich APIs, but Spartacus supports only parts of them, and treats them as implementation details. As a result, Spartacus does not support custom usage of `i18next` in your application.
 
 ## Getting Started
 
 For a quick start, import the predefined Spartacus translations (currently only in English) from `@spartacus/assets`, and register them with `provideConfig`. The following is an example:
 
 ```typescript
-import { translationsEn , translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
+import { translationsEn, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.35 or newer
 // import { translations, translationChunksConfig } from '@spartacus/assets'; // Use with version 2211.32.1 or older
 
 // ...
@@ -31,7 +31,7 @@ providers: [
   provideConfig({
     i18n: {
       resources: { en: translationsEn }, // Use with version 2211.35 or newer
-  //  resources: translations, // Use with version 2211.32.1 or older
+      //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
     },
   }),
@@ -78,9 +78,12 @@ import { translationsEn } from '@spartacus/assets'; // Use with version 2211.35 
 // ...
 
 export const translationOverwrites = {
-  en: { // lang
-    cart: { // chunk
-      cartDetails: { // keys (nested)
+  en: {
+    // lang
+    cart: {
+      // chunk
+      cartDetails: {
+        // keys (nested)
         proceedToCheckout: 'Proceed to Checkout',
       },
     },
@@ -92,7 +95,7 @@ export const translationOverwrites = {
 providers: [
   provideConfig({
     i18n: { resources: { en: translationsEn } }, // Use with version 2211.35 or newer
-//  i18n: { resources: translations }, // Use with version 2211.32.1 or older
+    //  i18n: { resources: translations }, // Use with version 2211.32.1 or older
   }),
   provideConfig({
     i18n: { resources: translationOverwrites },
@@ -119,8 +122,8 @@ import { translationsEn, translationChunksConfig } from '@spartacus/assets'; // 
 providers: [
   provideConfig({
     i18n: {
-      resources: { en: translationsEn } , // Use with version 2211.35 or newer
-  //  resources: translations, // Use with version 2211.32.1 or older
+      resources: { en: translationsEn }, // Use with version 2211.35 or newer
+      //  resources: translations, // Use with version 2211.32.1 or older
       chunks: translationChunksConfig,
       fallbackLang: 'en',
     },
@@ -146,7 +149,7 @@ interface TranslationResources {
 
 The `i18n.backend.loader` config property is introduced with Spartacus 6.1 and is recommended for better SSR performance, compared to the older `i18n.backend.loadPath` config property. The older `i18n.backend.loadPath` config property should only be used when storing translations in a remote endpoint.
 
-To enable lazy loading of JSON translation assets stored in a local project, configure the `i18n.backend.loader` property as a function  that returns a `Promise` with the translation chunk for the given language and chunk name. The following is an example:
+To enable lazy loading of JSON translation assets stored in a local project, configure the `i18n.backend.loader` property as a function that returns a `Promise` with the translation chunk for the given language and chunk name. The following is an example:
 
 {% raw %}
 
@@ -287,7 +290,7 @@ providers: [
 
 {% endraw %}
 
-The following is an example of the corresponding configuration in the `common.ts` file:
+The following is an example of the corresponding configuration in the `common.json` file:
 
 ```ts
 {
@@ -303,7 +306,7 @@ The following is an example of the corresponding configuration in the `common.ts
 }
 ```
 
-The following is an example of the corresponding configuration in the `cart.ts` file:
+The following is an example of the corresponding configuration in the `cart.json` file:
 
 ```ts
 {
@@ -328,6 +331,7 @@ chunks: [
 You can also pass parameters into the translation pipe, for example:
 
 {% raw %}
+
 ```html
 <p>{{ 'miniLogin.hello' | cxTranslate : { name: person.name } }}</p>
 ```
@@ -335,11 +339,12 @@ You can also pass parameters into the translation pipe, for example:
 ```ts
 // resources
 {
-    miniLogin: {
-        hello: 'Hello, {{ name }}'
-    }
+  miniLogin: {
+    hello: 'Hello, {{ name }}';
+  }
 }
 ```
+
 {% endraw %}
 
 ### Special Parameter: count
@@ -356,7 +361,7 @@ You can pass the `count` parameter to differ translations for the same key, depe
 
 {% endraw %}
 
-The following are the translation resources in the `common.ts` file for English:
+The following are the translation resources in the `common.json` file for English:
 
 {% raw %}
 
@@ -371,7 +376,7 @@ The following are the translation resources in the `common.ts` file for English:
 
 {% endraw %}
 
-For languages with more than two plural forms, numeric suffixes are used, such as `_0`, `_1`, ... `_5`, and so on. The following are the translation resources in the `cart.ts` file for Polish, which has three rules for pluralization:
+For languages with more than two plural forms, numeric suffixes are used, such as `_0`, `_1`, ... `_5`, and so on. The following are the translation resources in the `cart.json` file for Polish, which has three rules for pluralization:
 
 {% raw %}
 
@@ -460,9 +465,7 @@ getPaymentCardContent(payment: PaymentDetails): Observable<Card> {
 The translation is observable, so you must also add an `async` pipe to the template. The following is an example:
 
 ```html
-<cx-card
-    [content]="getPaymentCardContent(order.paymentInfo) | async"
-></cx-card>
+<cx-card [content]="getPaymentCardContent(order.paymentInfo) | async"></cx-card>
 ```
 
 ### Best Practices
@@ -525,7 +528,6 @@ The `cxDate` pipe is just a wrapper of Angular's `date` pipe, so it accepts the 
 **Note**: The `cxDate` pipe uses Angular's locale data, which only comes with English by default. For other locales, you need to register them explicitly in your app.module. The following is an example from the app.module:
 
 ```typescript
-
 import localeDe from '@angular/common/locales/de';
 import localeJa from '@angular/common/locales/ja';
 
@@ -559,7 +561,7 @@ To prevent injection attacks through translations, ensure that escaping is enabl
 providers: [
   provideConfig({
     i18n: {
-        ... 
+        ...
       interpolation: {
         escapeValue: true,
       }

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -434,9 +434,7 @@ If you need to make use of translations before the template, inject the translat
 ```typescript
 import { TranslationService } from '@spartacus/core';
 
-constructor(
-    private translation: TranslationService
-) {}
+private translation = inject(TranslationService);
 
 getPaymentCardContent(payment: PaymentDetails): Observable<Card> {
 ￼   return combineLatest([

--- a/_pages/dev/i18n.md
+++ b/_pages/dev/i18n.md
@@ -467,10 +467,7 @@ The translation is observable, so you must also add an `async` pipe to the templ
 
 In components, it is a best practice to use the `cxTranslate` pipe in the HTML template pipe, rather than the `TranslationService` in the TypeScript logic, unless there is a strong reason for using `TranslationService`.
 
-The disadvantages of using `TranslationService` are the following:
-
-- it introduces an unnecessary constructor dependency to the component TypeScript class
-- it might introduce unnecessary methods and RxJs Observable logic to the component TypeScript class
+The disadvantage of using `TranslationService`: it might introduce unnecessary methods and RxJs Observable logic to the component TypeScript class
 
 ## Upgrading
 


### PR DESCRIPTION
- change .ts to .json - Reason: we changed to JSON translation files in our repo long time ago
- change ctr to `inject` for DI - Reason: use modern syntax in docs