### PR TITLE
docs: fix more than one typos

### DIFF
--- a/_pages/dev/backend_communication/loading-scopes.md
+++ b/_pages/dev/backend_communication/loading-scopes.md
@@ -65,7 +65,7 @@ When you are working with the Spartacus `OccProductAdapter`, you can configure s
 }
 ```
 
-Spartacus  preprocesses these fields to optimize calls to the back end, especially to limit the number of calls if more that one scope is requested at the same time.
+Spartacus preprocesses these fields to optimize calls to the back end, especially to limit the number of calls if more than one scope is requested at the same time.
 
 Ideally, `fields` descriptions should be as specific as possible, and aliases such as `BASIC`, `DEFAULT` and `FULL` should be avoided, where possible.
 

--- a/_pages/dev/components/customizing-cms-components.md
+++ b/_pages/dev/components/customizing-cms-components.md
@@ -115,7 +115,7 @@ provideConfig({
 });
 ```
 
-One JS file can contain more that one web component implementation, with each implementation used as a different `CmsComponent`.
+One JS file can contain more than one web component implementation, with each implementation used as a different `CmsComponent`.
 
 This requires a separate build process to generate the JS chunk that holds the web component (or components), which is out of scope for this documentation.
 

--- a/_pages/dev/features/quick-order.md
+++ b/_pages/dev/features/quick-order.md
@@ -171,7 +171,7 @@ You can add products to the quick order list and then to your cart, as follows:
 
    <img src="{{ site.baseurl }}/assets/images/quick-order-8.png" alt="Quick Order Form Suggestion Box" width="700" border="1px" />
  
-   If there is only one product in the suggestions, you can press <kbd>Enter</kbd> to add the product. If there is more that one  product, you can select which product to add by clicking on it, or by navigating to the product using the arrow keys on your keyboard, and then confirming your selection by pressing <kbd>Enter</kbd>.
+   If there is only one product in the suggestions, you can press <kbd>Enter</kbd> to add the product. If there is more than one product, you can select which product to add by clicking on it, or by navigating to the product using the arrow keys on your keyboard, and then confirming your selection by pressing <kbd>Enter</kbd>.
 
    The newly-added product appears in the quick order list.
 


### PR DESCRIPTION
Fixes three occurrences of 'more that one' in the docs. Closes #1138. Checks: typo search and git diff --check.