### PR TITLE
docs: Remove references to avoidCachingErrors SSR feature toggle

### DIFF
--- a/_pages/dev/ssr/server-side-rendering-error-handling.md
+++ b/_pages/dev/ssr/server-side-rendering-error-handling.md
@@ -52,7 +52,6 @@ If your Spartacus app was created before version 2211.29, to benefit from all as
 
 - Enable the `propagateErrorsToServer` feature update toggle to start propagating the errors caught during server-side rendering to the ExpressJS server, where eventually they will be properly handled. For more information, see [Propagating Errors To The Server](#propagating-errors-to-the-server) and [Activating Propagate to Server](link to doc on help portal).
 - Enable the `ssrStrictErrorHandlingForHttpAndNgrx` feature update toggle to seal the Angular application from the asynchronous errors that occur in the NgRx flow and from HTTP calls during the rendering process. For more information, see [Strict Error Handling for HTTP And NgRx](#strict-error-handling-in-angular-for-http-and-ngrx) and [Activating SSR Strict Error Handling For HTTP and Ngrx](link to doc on help portal).
-- Enable `ssrFeatureToggle.avoidCachingErrors` in `SsrOptimizationOptions` to not cache any pages where an error occurs during rendering. For more information, see [Cache management and error handling](#cache-management-and-error-handling) and [Activating Avoid Cache Error](link to doc on help portal).
 - Use the `defaultExpressErrorHandlers` middleware in `server.ts` to handle errors in ExpressJS. For more information, see [Using Default ExpressJS Error Handlers](#using-default-expressjs-error-handlers).
 - Ensure that the `provideServer()` config function is provided in the `app.server.module.ts` file. It contains elements that are required for SSR error handling to work properly.
 
@@ -346,7 +345,7 @@ shouldCacheRenderingResult?: ({
   }) => boolean;
 ```
 
-By default, all HTML rendering results are cached. Also, all errors are cached by default, unless the separate `ssrFeatureToggles.avoidCachingErrors` option is enabled.
+By default, all HTML rendering results are cached and errors are not.
 
 If needed, the caching strategy can be easily customized by providing its own function.
 

--- a/_pages/dev/ssr/server-side-rendering-optimization.md
+++ b/_pages/dev/ssr/server-side-rendering-optimization.md
@@ -80,11 +80,7 @@ By default, the SSR optimization engine uses the following configuration:
     defaultRenderingStrategyResolverOptions
   ),
   logger: new DefaultExpressServerLogger(),
-  shouldCacheRenderingResult: ({ options, entry }) =>
-    !(
-      options.ssrFeatureToggles?.avoidCachingErrors === true &&
-      Boolean(entry.err)
-    ),
+  shouldCacheRenderingResult: ({ entry: { err } }) => !err,
 }
 ```
 
@@ -147,8 +143,6 @@ The default implementation is the `DefaultCacheEntrySizeCalculator` class. For a
 The `DefaultCacheEntrySizeCalculator` estimates the size of the error by summing up its three string properties: `name`, `message`, and `trace`. Although this calculation does not provide perfect results (because it can lead to underestimation, especially when the error object has numerous additional properties, or it is not actually an instance of an `Error` object, such as `cacheEntry.err`, which can be an object of any type), in general, the default `cacheEntrySizeCalculator` should be sufficient.
 
 Although caching error objects is not recommended, if you wish to cache certain error objects, the `cacheEntrySizeCalculator` allows you to customize the default logic for calculating the size of cached errors.
-
-To avoid caching error objects, enable the `ssrFeatureToggles.avoidCachingErrors` feature toggle. For more information on enabling this toggle, see [Activating Avoid Caching Errors](https://help.sap.com/docs/SAP_COMMERCE_COMPOSABLE_STOREFRONT/10a8bc7f635b4e3db6f6bb7880e58a7d/cee75ac05742431986af71f3884fe84c.html?locale=en-US).
 
 ### cacheSize
 
@@ -249,7 +243,7 @@ The logger property is optional. By default, the `DefaultExpressServerLogger` is
 
 When caching is enabled, this function indicates whether the given rendering result (HTML or an error) should be cached.
 
-By default, all HTML rendering results are cached. Also, all errors are cached by default, unless the `avoidCachingErrors` SSR feature toggle is enabled.
+By default, all HTML rendering results are cached and errors are not.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Updates the SSR error-handling and optimization docs to reflect that errors are no longer cached by default, and the `ssrFeatureToggles.avoidCachingErrors` toggle is no longer needed.

## Changes

- **`_pages/dev/ssr/server-side-rendering-error-handling.md`**
  - Remove the bullet instructing users to enable `ssrFeatureToggle.avoidCachingErrors` in `SsrOptimizationOptions`.
  - Update the description of default caching behavior: errors are now not cached by default.

- **`_pages/dev/ssr/server-side-rendering-optimization.md`**
  - Simplify the default `shouldCacheRenderingResult` example to `({ entry: { err } }) => !err`.
  - Remove the paragraph (and broken-style help-portal link) instructing users to enable the `avoidCachingErrors` feature toggle.
  - Update the description of default caching behavior consistently with the error-handling doc.